### PR TITLE
added handler for unhandled exceptions 

### DIFF
--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using Fabric.Authorization.API.Configuration;
 using Fabric.Authorization.API.Extensions;
@@ -24,6 +25,7 @@ using Serilog;
 using Serilog.Core;
 using Swagger.ObjectModel;
 using Swagger.ObjectModel.Builders;
+using HttpResponseHeaders = Fabric.Authorization.API.Constants.HttpResponseHeaders;
 
 namespace Fabric.Authorization.API
 {
@@ -71,10 +73,10 @@ namespace Fabric.Authorization.API
 
             pipelines.AfterRequest += ctx =>
             {
-                ctx.Response.Headers.Add("Access-Control-Allow-Origin", "*");
-                ctx.Response.Headers.Add("Access-Control-Allow-Headers",
-                    "Origin, X-Requested-With, Content-Type, Accept, Authorization");
-                ctx.Response.Headers.Add("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
+                foreach (var corsHeader in HttpResponseHeaders.CorsHeaders)
+                {
+                    ctx.Response.Headers.Add(corsHeader.Item1, corsHeader.Item2);
+                }
             };
 
             ConfigureRegistrations(container);
@@ -95,10 +97,7 @@ namespace Fabric.Authorization.API
                     Message = "There was an internal server error while processing the request.",
                     Code = ((int)HttpStatusCode.InternalServerError).ToString()
                 })
-                .WithHeader("Access-Control-Allow-Origin", "*")
-                .WithHeader("Access-Control-Allow-Headers",
-                    "Origin, X-Requested-With, Content-Type, Accept, Authorization")
-                .WithHeader("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
+                .WithHeaders(HttpResponseHeaders.CorsHeaders);
 
 
             var response = responseNegotiator.NegotiateResponse(negotiator, context);            

--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -150,19 +150,14 @@ namespace Fabric.Authorization.API
         protected void ApplicationStartupForTests(TinyIoCContainer container, IPipelines pipelines)
         {
             base.ApplicationStartup(container, pipelines);
-            pipelines.OnError.AddItemToEndOfPipeline((ctx, ex) =>
-            {
-                _logger.Error(ex, "Unhandled error on request: @{Url}. Error Message: @{Message}", ctx.Request.Url,
-                    ex.Message);
-                return ctx.Response;
-            });
+            pipelines.OnError.AddItemToEndOfPipeline((ctx, ex) => HandleInternalServerError(ctx, ex, container.Resolve<IResponseNegotiator>()));
 
             pipelines.AfterRequest += ctx =>
             {
-                ctx.Response.Headers.Add("Access-Control-Allow-Origin", "*");
-                ctx.Response.Headers.Add("Access-Control-Allow-Headers",
-                    "Origin, X-Requested-With, Content-Type, Accept, Authorization");
-                ctx.Response.Headers.Add("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE, OPTIONS");
+                foreach (var corsHeader in HttpResponseHeaders.CorsHeaders)
+                {
+                    ctx.Response.Headers.Add(corsHeader.Item1, corsHeader.Item2);
+                }
             };
 
             //container registrations

--- a/Fabric.Authorization.API/Constants/HttpResponseHeaders.cs
+++ b/Fabric.Authorization.API/Constants/HttpResponseHeaders.cs
@@ -1,7 +1,15 @@
-﻿namespace Fabric.Authorization.API.Constants
+﻿using System;
+
+namespace Fabric.Authorization.API.Constants
 {
     public static class HttpResponseHeaders
     {
         public static readonly string Location = "Location";
+        public static readonly Tuple<string, string>[] CorsHeaders = 
+        {
+            new Tuple<string, string>("Access-Control-Allow-Origin", "*"),
+            new Tuple<string, string>("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization"),  
+            new Tuple<string, string>("Access-Control-Allow-Methods", "POST, GET, PUT, DELETE") 
+        };
     }
 }

--- a/Fabric.Authorization.API/Infrastructure/PipelineHooks/OnErrorHooks.cs
+++ b/Fabric.Authorization.API/Infrastructure/PipelineHooks/OnErrorHooks.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.API.Models;
+using Nancy;
+using Nancy.Responses.Negotiation;
+using Serilog;
+
+namespace Fabric.Authorization.API.Infrastructure.PipelineHooks
+{
+    public class OnErrorHooks
+    {
+        private readonly ILogger _logger;
+
+        public OnErrorHooks(ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        internal dynamic HandleInternalServerError(NancyContext context, Exception exception,
+            IResponseNegotiator responseNegotiator)
+        {
+            _logger.Error(exception, "Unhandled error on request: @{Url}. Error Message: @{Message}", context.Request.Url,
+                exception.Message);
+
+            context.NegotiationContext = new NegotiationContext();
+
+            var negotiator = new Negotiator(context)
+                .WithStatusCode(HttpStatusCode.InternalServerError)
+                .WithModel(new Error()
+                {
+                    Message = "There was an internal server error while processing the request.",
+                    Code = ((int)HttpStatusCode.InternalServerError).ToString()
+                })
+                .WithHeaders(HttpResponseHeaders.CorsHeaders);
+
+
+            var response = responseNegotiator.NegotiateResponse(negotiator, context);
+            return response;
+        }
+    }
+}

--- a/Fabric.Authorization.API/Infrastructure/PipelineHooks/RequestHooks.cs
+++ b/Fabric.Authorization.API/Infrastructure/PipelineHooks/RequestHooks.cs
@@ -4,7 +4,7 @@ using System.Net;
 using System.Text.RegularExpressions;
 using Nancy;
 
-namespace Fabric.Authorization.API
+namespace Fabric.Authorization.API.Infrastructure.PipelineHooks
 {
     public static class RequestHooks
     {

--- a/Fabric.Authorization.API/Startup.cs
+++ b/Fabric.Authorization.API/Startup.cs
@@ -62,7 +62,7 @@ namespace Fabric.Authorization.API
                 .UseOwin()
                 .UseFabricLoggingAndMonitoring(_logger, HealthCheck, _levelSwitch)
                 .UseAuthPlatform(_idServerSettings.Scopes, _allowedPaths)
-                .UseNancy(opt => opt.Bootstrapper = new Bootstrapper(_logger, _appConfig, _levelSwitch));
+                .UseNancy(opt => opt.Bootstrapper = new Bootstrapper(_logger, _appConfig, _levelSwitch, env));
         }
 
         public async Task<bool> HealthCheck()

--- a/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using Fabric.Authorization.API;
 using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.API.Models;
 using Fabric.Authorization.API.Modules;
 using Fabric.Authorization.Domain.Stores;

--- a/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using Fabric.Authorization.API;
 using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.API.Models;
 using Fabric.Authorization.API.Modules;
 using Fabric.Authorization.Domain.Stores;

--- a/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using Fabric.Authorization.API;
 using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.API.Modules;
 using Fabric.Authorization.Domain.Stores;
 using Fabric.Authorization.Domain.Stores.CouchDB;

--- a/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using Fabric.Authorization.API;
 using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.API.Modules;
 using Fabric.Authorization.Domain.Stores;
 using Fabric.Authorization.Domain.Stores.CouchDB;

--- a/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using Fabric.Authorization.API;
 using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.API.Models;
 using Fabric.Authorization.API.Modules;
 using Fabric.Authorization.Domain.Stores;

--- a/Fabric.Authorization.UnitTests/ModuleTestsBase.cs
+++ b/Fabric.Authorization.UnitTests/ModuleTestsBase.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Security.Claims;
 using Fabric.Authorization.API;
+using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.Domain.Models;
 using Fabric.Authorization.Domain.Stores;
 using Fabric.Authorization.UnitTests.Mocks;


### PR DESCRIPTION
i added a handler for dealing with unhandled exceptions (approach taken from here https://bytefish.de/blog/consistent_error_handling_with_nancy/). this way we can set a custom message and more importantly add the CORS headers to the response so that javascript applications can read the response. currently it only handles unhandled exceptions but in the future we can add handling for 404's and in the platform middleware we should be able to handle 403's. relevant code is in the class OnErrorHooks

i also moved the cors headers to the HttpResponseHeaders class so we can reuse them. 