### PR TITLE
ensure subject is used instead of userid. 

### DIFF
--- a/Fabric.Authorization.API/Constants/Claims.cs
+++ b/Fabric.Authorization.API/Constants/Claims.cs
@@ -5,5 +5,6 @@
         public static readonly string Scope = "scope";
         public static readonly string ClientId = "client_id";
         public static readonly string Sub = "sub";
+        public static readonly string IdentityProvider = "idp";
     }
 }

--- a/Fabric.Authorization.API/Models/ModelExtensions.cs
+++ b/Fabric.Authorization.API/Models/ModelExtensions.cs
@@ -52,7 +52,7 @@ namespace Fabric.Authorization.API.Models
         {
             var userApiModel = new UserApiModel
             {
-                UserId = user.Id,
+                SubjectId = user.SubjectId,
                 Groups = user.Groups
             };
 

--- a/Fabric.Authorization.API/Models/ModelExtensions.cs
+++ b/Fabric.Authorization.API/Models/ModelExtensions.cs
@@ -52,7 +52,7 @@ namespace Fabric.Authorization.API.Models
         {
             var userApiModel = new UserApiModel
             {
-                SubjectId = user.SubjectId,
+                UserId = user.Id,
                 Groups = user.Groups
             };
 

--- a/Fabric.Authorization.API/Models/UserApiModel.cs
+++ b/Fabric.Authorization.API/Models/UserApiModel.cs
@@ -4,7 +4,7 @@ namespace Fabric.Authorization.API.Models
 {
     public class UserApiModel
     {
-        public string UserId { get; set; }
+        public string SubjectId { get; set; }
 
         public IEnumerable<string> Groups { get; set; }
     }

--- a/Fabric.Authorization.API/Models/UserApiModel.cs
+++ b/Fabric.Authorization.API/Models/UserApiModel.cs
@@ -4,7 +4,7 @@ namespace Fabric.Authorization.API.Models
 {
     public class UserApiModel
     {
-        public string SubjectId { get; set; }
+        public string UserId { get; set; }
 
         public IEnumerable<string> Groups { get; set; }
     }

--- a/Fabric.Authorization.API/Modules/FabricModule.cs
+++ b/Fabric.Authorization.API/Modules/FabricModule.cs
@@ -109,6 +109,7 @@ namespace Fabric.Authorization.API.Modules
         }
 
         protected string SubjectId => Context.CurrentUser.Claims.First(c => c.Type == Claims.Sub).Value;
+        protected string IdentityProvider => Context.CurrentUser.Claims.First(c => c.Type == Claims.IdentityProvider).Value;
 
         protected Predicate<Claim> GetClientIdPredicate(string clientId)
         {

--- a/Fabric.Authorization.API/Modules/GroupsModule.cs
+++ b/Fabric.Authorization.API/Modules/GroupsModule.cs
@@ -246,8 +246,7 @@ namespace Fabric.Authorization.API.Modules
                     throw new NotFoundException<User>();
                 }
 
-                var group = await _groupService.DeleteUserFromGroup(groupUserRequest.GroupName,
-                    groupUserRequest.SubjectId);
+                var group = await _groupService.DeleteUserFromGroup(groupUserRequest.GroupName, groupUserRequest.SubjectId, groupUserRequest.IdentityProvider);
                 return CreateSuccessfulPostResponse(group.ToGroupUserApiModel(), HttpStatusCode.OK);
             }
             catch (NotFoundException<Group> ex)

--- a/Fabric.Authorization.API/Modules/GroupsModule.cs
+++ b/Fabric.Authorization.API/Modules/GroupsModule.cs
@@ -213,6 +213,7 @@ namespace Fabric.Authorization.API.Modules
                 {
                     return CreateFailureResponse("subjectId is required", HttpStatusCode.BadRequest);
                 }
+            
                 if (string.IsNullOrWhiteSpace(groupUserRequest.IdentityProvider))
                 {
                     return CreateFailureResponse("identityProvider is required", HttpStatusCode.BadRequest);

--- a/Fabric.Authorization.API/Modules/UsersMetadataModule.cs
+++ b/Fabric.Authorization.API/Modules/UsersMetadataModule.cs
@@ -22,7 +22,7 @@ namespace Fabric.Authorization.API.Modules
         private readonly Parameter _userIdParameter = new Parameter
         {
             Name = "userId",
-            Description = "UserId to use for the request",
+            Description = "SubjectId to use for the request",
             In = ParameterIn.Path,
             Required = true,
             Type = "integer"

--- a/Fabric.Authorization.API/Modules/UsersModule.cs
+++ b/Fabric.Authorization.API/Modules/UsersModule.cs
@@ -45,7 +45,7 @@ namespace Fabric.Authorization.API.Modules
                 async param => await this.AddGranularPermissions(param, denied: true).ConfigureAwait(false), null,
                 "AddDeniedPermissions");
 
-            Get("/{subjectId}/groups", async _ => await GetUserGroups().ConfigureAwait(false), null, "GetUserGroups");
+            Get("/{userId}/groups", async _ => await GetUserGroups().ConfigureAwait(false), null, "GetUserGroups");
         }
 
         private async Task<dynamic> GetUserGroups()
@@ -86,7 +86,7 @@ namespace Fabric.Authorization.API.Modules
                 AuthorizationReadClaim);
 
             var subjectId = SubjectId;
-            var groups = await GetGroupsForAuthenticatedUser(subjectId);
+            var groups = await GetGroupsForAuthenticatedUser(subjectId).ConfigureAwait(false);
 
             var permissions = await _permissionService.GetPermissionsForUser(
                 subjectId,

--- a/Fabric.Authorization.API/RemoteServices/Identity/Models/UserSearchRequest.cs
+++ b/Fabric.Authorization.API/RemoteServices/Identity/Models/UserSearchRequest.cs
@@ -5,6 +5,6 @@ namespace Fabric.Authorization.API.RemoteServices.Identity.Models
     public class UserSearchRequest
     {
         public string ClientId { get; set; }
-        public IEnumerable<string> DocumentIds { get; set; }
+        public IEnumerable<string> UserIds { get; set; }
     }
 }

--- a/Fabric.Authorization.API/RemoteServices/Identity/Providers/IdentityServiceProvider.cs
+++ b/Fabric.Authorization.API/RemoteServices/Identity/Providers/IdentityServiceProvider.cs
@@ -23,7 +23,7 @@ namespace Fabric.Authorization.API.RemoteServices.Identity.Providers
             _appConfiguration = appConfiguration;
         }
 
-        public async Task<IEnumerable<UserSearchResponse>> Search(string clientId, IEnumerable<string> documentIds)
+        public async Task<IEnumerable<UserSearchResponse>> Search(string clientId, IEnumerable<string> userIds)
         {
             // get all users in groups tied to clientRoles
             var httpClient =
@@ -34,7 +34,7 @@ namespace Fabric.Authorization.API.RemoteServices.Identity.Providers
             var request = new UserSearchRequest
             {
                 ClientId = clientId,
-                DocumentIds = documentIds
+                UserIds = userIds
             };
 
             var response = await httpClient.PostAsync("/users",

--- a/Fabric.Authorization.Domain/Models/Formatters/Formatters.cs
+++ b/Fabric.Authorization.Domain/Models/Formatters/Formatters.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Fabric.Authorization.Domain.Models.Formatters
+{
+    public class UserIdentifierFormatter : IIdentifierFormatter<User>
+    {
+        public string Format(User user)
+        {
+            if (user == null)
+            {
+                throw new ArgumentNullException(nameof(user), "user cannot be null");
+            }
+
+            return !string.IsNullOrWhiteSpace(user.IdentityProvider)
+                ? $"{user.SubjectId}:{user.IdentityProvider}"
+                : user.SubjectId;
+        }
+    }
+}

--- a/Fabric.Authorization.Domain/Models/Formatters/IIdentifierFormatter.cs
+++ b/Fabric.Authorization.Domain/Models/Formatters/IIdentifierFormatter.cs
@@ -1,0 +1,7 @@
+﻿namespace Fabric.Authorization.Domain.Models.Formatters
+{
+    public interface IIdentifierFormatter<T>
+    {
+        string Format(T entity);
+    }
+}

--- a/Fabric.Authorization.Domain/Models/GranularPermission.cs
+++ b/Fabric.Authorization.Domain/Models/GranularPermission.cs
@@ -5,13 +5,15 @@ namespace Fabric.Authorization.Domain.Models
 {
     public class GranularPermission : ITrackable, IIdentifiable, ISoftDelete
     {
-        public string Id => this.Target;
+        public string Id => Target;
 
         public IEnumerable<Permission> DeniedPermissions { get; set; }
 
         public IEnumerable<Permission> AdditionalPermissions { get; set; }
 
         public string Target { get; set; }
+
+        public string Identifier => Id;
 
         public bool IsDeleted { get; set; }
 
@@ -22,8 +24,6 @@ namespace Fabric.Authorization.Domain.Models
         public string CreatedBy { get; set; }
 
         public string ModifiedBy { get; set; }
-
-        public string Identifier => this.Id.ToString();
 
         public override string ToString()
         {

--- a/Fabric.Authorization.Domain/Models/User.cs
+++ b/Fabric.Authorization.Domain/Models/User.cs
@@ -1,18 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using Fabric.Authorization.Domain.Models.Formatters;
 
 namespace Fabric.Authorization.Domain.Models
 {
     public class User : ITrackable, IIdentifiable, ISoftDelete
     {
-        public User()
+        public User(string subjectId, string identityProvider)
         {
+            SubjectId = subjectId;
+            IdentityProvider = identityProvider;
+            Id = Identifier;
             Groups = new List<string>();
         }
 
         public string Id { get; set; }
 
-        public string Identifier => Id;
+        public string Identifier => new UserIdentifierFormatter().Format(this);
 
         public string SubjectId { get; set; }
 

--- a/Fabric.Authorization.Domain/Stores/CouchDB/CouchDbUserStore.cs
+++ b/Fabric.Authorization.Domain/Stores/CouchDB/CouchDbUserStore.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Fabric.Authorization.Domain.Models;
 using Fabric.Authorization.Domain.Services;
 using Serilog;
@@ -16,13 +15,17 @@ namespace Fabric.Authorization.Domain.Stores.CouchDB
 
         public override async Task<User> Add(User model)
         {
-            model.Id = model.SubjectId;
-            return await base.Add(model.Id, model);
+            return await base.Add(ReplaceInvalidChars(model.Identifier), model);
         }
 
         public override async Task Delete(User model)
         {
-            await base.Delete(model.Id, model);
+            await base.Delete(ReplaceInvalidChars(model.Identifier), model);
+        }
+
+        public static string ReplaceInvalidChars(string documentId)
+        {
+            return documentId.Replace(@"\", "::");
         }
     }
 }

--- a/Fabric.Authorization.Domain/Stores/InMemory/InMemoryUserStore.cs
+++ b/Fabric.Authorization.Domain/Stores/InMemory/InMemoryUserStore.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Fabric.Authorization.Domain.Models;
@@ -10,17 +9,21 @@ namespace Fabric.Authorization.Domain.Stores.InMemory
     {
         public override async Task<User> Add(User model)
         {
-            model.Id = model.SubjectId;
+            model.Id = model.Identifier;
             return await base.Add(model);
         }
 
-        public Task<IEnumerable<User>> GetUsers(string subjectId = null)
+        public Task<IEnumerable<User>> GetUsers(string subjectId = null, string identityProvider = null)
         {
             var users = Dictionary.Select(kvp => kvp.Value);
 
             if (!string.IsNullOrEmpty(subjectId))
             {
-                users = users.Where(r => r.SubjectId == subjectId);
+                users = users.Where(u => u.SubjectId == subjectId);
+            }
+            if (!string.IsNullOrEmpty(identityProvider))
+            {
+                users = users.Where(u => u.IdentityProvider == identityProvider);
             }
 
             return Task.FromResult(users.Where(u => !u.IsDeleted));

--- a/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
+++ b/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
@@ -138,10 +138,10 @@ namespace Fabric.Authorization.Domain.Stores.Services
             }
             catch (NotFoundException<User>)
             {
-                user = await _userStore.Add(new User {SubjectId = subjectId, IdentityProvider = identityProvider});
+                user = await _userStore.Add(new User(subjectId, identityProvider));
             }
 
-            if (group.Users.All(u => u.SubjectId != subjectId))
+            if (group.Users.All(u => u.SubjectId != subjectId && u.IdentityProvider != identityProvider))
             {
                 group.Users.Add(user);
             }
@@ -156,12 +156,15 @@ namespace Fabric.Authorization.Domain.Stores.Services
             return group;
         }
 
-        public async Task<Group> DeleteUserFromGroup(string groupName, string subjectId)
+        public async Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider)
         {
             var group = await _groupStore.Get(groupName);
             var user = await _userStore.Get(subjectId);
 
-            var groupUser = group.Users.FirstOrDefault(u => u.SubjectId == subjectId);
+            var groupUser = group.Users.FirstOrDefault(u => 
+                u.Id == subjectId
+                && u.IdentityProvider == identityProvider);
+
             if (groupUser != null)
             {
                 group.Users.Remove(groupUser);

--- a/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
+++ b/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
@@ -126,6 +126,7 @@ namespace Fabric.Authorization.Domain.Stores.Services
         {
             var group = await _groupStore.Get(groupName);
 
+            //only add users to a custom group
             if (!string.Equals(group.Source, GroupConstants.CustomSource))
             {
                 throw new BadRequestException<Group>();
@@ -134,7 +135,7 @@ namespace Fabric.Authorization.Domain.Stores.Services
             User user;
             try
             {
-                user = await _userStore.Get(subjectId);
+                user = await _userStore.Get($"{subjectId}:{identityProvider}");
             }
             catch (NotFoundException<User>)
             {
@@ -159,11 +160,10 @@ namespace Fabric.Authorization.Domain.Stores.Services
         public async Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider)
         {
             var group = await _groupStore.Get(groupName);
-            var user = await _userStore.Get(subjectId);
+            var user = await _userStore.Get($"{subjectId}:{identityProvider}");
 
             var groupUser = group.Users.FirstOrDefault(u => 
-                u.Id == subjectId
-                && u.IdentityProvider == identityProvider);
+                u.Id == user.Id);
 
             if (groupUser != null)
             {

--- a/Fabric.Authorization.Domain/Stores/Services/UserService.cs
+++ b/Fabric.Authorization.Domain/Stores/Services/UserService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using Fabric.Authorization.Domain.Models;
 
 namespace Fabric.Authorization.Domain.Stores.Services
 {
@@ -11,11 +10,6 @@ namespace Fabric.Authorization.Domain.Stores.Services
         public UserService(IUserStore userStore)
         {
             _userStore = userStore;
-        }
-
-        public async Task<User> GetUser(string subjectId)
-        {
-            return await _userStore.Get(subjectId);
         }
 
         public async Task<IEnumerable<string>> GetGroupsForUser(string subjectId)

--- a/Fabric.Authorization.Domain/Stores/Services/UserService.cs
+++ b/Fabric.Authorization.Domain/Stores/Services/UserService.cs
@@ -12,9 +12,9 @@ namespace Fabric.Authorization.Domain.Stores.Services
             _userStore = userStore;
         }
 
-        public async Task<IEnumerable<string>> GetGroupsForUser(string subjectId)
+        public async Task<IEnumerable<string>> GetGroupsForUser(string subjectId, string identityProvider)
         {
-            var user = await _userStore.Get(subjectId);
+            var user = await _userStore.Get($"{subjectId}:{identityProvider}");
             return user.Groups;
         }
     }

--- a/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
@@ -83,7 +83,8 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                         new Claim(Claims.Scope, Scopes.ManageClientsScope),
                         new Claim(Claims.Scope, Scopes.ReadScope),
                         new Claim(Claims.Scope, Scopes.WriteScope),
-                        new Claim(Claims.ClientId, "rolesprincipal")
+                        new Claim(Claims.ClientId, "rolesprincipal"),
+                        new Claim(Claims.IdentityProvider, "idP1")
                     }, "rolesprincipal"));
                     pipelines.BeforeRequest += ctx => RequestHooks.SetDefaultVersionInUrl(ctx);
                 });
@@ -768,7 +769,8 @@ namespace Fabric.Authorization.IntegrationTests.Modules
             const string group1Name = "Group1Name";
             SetupGroup(group1Name, "Custom");
             const string subject1Id = "Subject1Id";
-            var response = SetupGroupUserMapping(group1Name, subject1Id, "idP1");
+            const string identityProvider = "idP1";
+            var response = SetupGroupUserMapping(group1Name, subject1Id, identityProvider);
 
             Assert.Equal(HttpStatusCode.Created, response.StatusCode);
 
@@ -778,6 +780,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 with.HttpRequest();
                 with.Header("Accept", "application/json");
                 with.FormValue("SubjectId", subject1Id);
+                with.FormValue("IdentityProvider", identityProvider);
             }).Result;
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -795,7 +798,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
             Assert.Equal(0, userList.Count);
 
             // ensure the deletion is reflected in the user model
-            response = Browser.Get($"/user/{subject1Id}/groups", with =>
+            response = Browser.Get($"/user/{subject1Id}/{identityProvider}/groups", with =>
             {
                 with.HttpRequest();
                 with.Header("Accept", "application/json");
@@ -854,10 +857,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         public void GetGroupsForUser_GroupAndUserExist_Success()
         {
             const string groupName = "GroupName";
+            const string subjectId = "Subject1Name";
+            const string identityProvider = "idP1";
             SetupGroup(groupName, "Custom");
-            SetupGroupUserMapping(groupName, "Subject1Name", "idP1");
+            SetupGroupUserMapping(groupName, subjectId, identityProvider);
 
-            var response = Browser.Get("/user/Subject1Name/groups", with =>
+            var response = Browser.Get($"/user/{subjectId}/{identityProvider}/groups", with =>
             {
                 with.HttpRequest();
                 with.Header("Accept", "application/json");

--- a/Fabric.Authorization.IntegrationTests/Modules/IdentitySearchTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/IdentitySearchTests.cs
@@ -111,7 +111,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
 
             var mockIdentityServiceProvider = new Mock<IIdentityServiceProvider>();
             mockIdentityServiceProvider
-                .Setup(m => m.Search(Fixture.AtlasClientId, new List<string> {"atlas_user:Windows"}))
+                .Setup(m => m.Search(Fixture.AtlasClientId, new List<string> { "atlas_user:Windows" }))
                 .ReturnsAsync(() => new List<UserSearchResponse>
                 {
                     new UserSearchResponse
@@ -232,7 +232,8 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                         new Claim(Claims.Scope, Scopes.ManageClientsScope),
                         new Claim(Claims.Scope, Scopes.ReadScope),
                         new Claim(Claims.Scope, Scopes.WriteScope),
-                        new Claim(Claims.ClientId, AtlasClientId)
+                        new Claim(Claims.ClientId, AtlasClientId),
+                        new Claim(Claims.IdentityProvider, "idP1")
                     }, "rolesprincipal"));
                     pipelines.BeforeRequest += ctx => RequestHooks.SetDefaultVersionInUrl(ctx);
                 });

--- a/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
@@ -83,7 +83,8 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                             new Claim(Claims.ClientId, "userprincipal"),
                             new Claim(Claims.Sub, "userprincipal"),
                             new Claim(JwtClaimTypes.Role, Group1),
-                            new Claim(JwtClaimTypes.Role, Group2)
+                            new Claim(JwtClaimTypes.Role, Group2),
+                            new Claim(JwtClaimTypes.IdentityProvider, "idP1")
                         }, "userprincipal"));
                     pipelines.BeforeRequest += (ctx) => RequestHooks.SetDefaultVersionInUrl(ctx);
                 });

--- a/Fabric.Authorization.UnitTests/Mocks/UserStoreMockExtensions.cs
+++ b/Fabric.Authorization.UnitTests/Mocks/UserStoreMockExtensions.cs
@@ -15,15 +15,15 @@ namespace Fabric.Authorization.UnitTests.Mocks
             mockUserStore.Setup(userStore => userStore.Get(It.IsAny<string>()))
                 .Returns((string userId) =>
                 {
-                    if (users.Any(c => c.Id== userId))
+                    if (users.Any(c => c.SubjectId == userId))
                     {
-                        return Task.FromResult(users.First(c => c.Id == userId));
+                        return Task.FromResult(users.First(c => c.SubjectId == userId));
                     }
                     throw new NotFoundException<User>();
                 });
 
             mockUserStore.Setup(userStore => userStore.Exists(It.IsAny<string>()))
-                .Returns((string userId) => Task.FromResult(users.Any(c => c.Id == userId)));
+                .Returns((string userId) => Task.FromResult(users.Any(c => c.SubjectId == userId)));
 
             mockUserStore.Setup(userStore => userStore.GetAll())
                 .Returns(() => Task.FromResult(users.AsEnumerable()));

--- a/Fabric.Authorization.UnitTests/Mocks/UserStoreMockExtensions.cs
+++ b/Fabric.Authorization.UnitTests/Mocks/UserStoreMockExtensions.cs
@@ -15,15 +15,15 @@ namespace Fabric.Authorization.UnitTests.Mocks
             mockUserStore.Setup(userStore => userStore.Get(It.IsAny<string>()))
                 .Returns((string userId) =>
                 {
-                    if (users.Any(c => c.SubjectId == userId))
+                    if (users.Any(c => c.Id == userId))
                     {
-                        return Task.FromResult(users.First(c => c.SubjectId == userId));
+                        return Task.FromResult(users.First(c => c.Id == userId));
                     }
                     throw new NotFoundException<User>();
                 });
 
             mockUserStore.Setup(userStore => userStore.Exists(It.IsAny<string>()))
-                .Returns((string userId) => Task.FromResult(users.Any(c => c.SubjectId == userId)));
+                .Returns((string userId) => Task.FromResult(users.Any(c => c.Id == userId)));
 
             mockUserStore.Setup(userStore => userStore.GetAll())
                 .Returns(() => Task.FromResult(users.AsEnumerable()));

--- a/Fabric.Authorization.UnitTests/Search/IdentitySearchServiceTests.cs
+++ b/Fabric.Authorization.UnitTests/Search/IdentitySearchServiceTests.cs
@@ -244,10 +244,8 @@ namespace Fabric.Authorization.UnitTests.Search
                 Name = UserPatientSafetyGroupName,
                 Users = new List<User>
                 {
-                    new User
+                    new User("patientsafety_user", "Windows")
                     {
-                        SubjectId = "patientsafety_user",
-                        IdentityProvider = "Windows",
                         Groups = new List<string> {UserPatientSafetyGroupName}
                     }
                 },
@@ -321,7 +319,7 @@ namespace Fabric.Authorization.UnitTests.Search
                 Name = UserAtlasGroupName,
                 Users = new List<User>
                 {
-                    new User
+                    new User("atlas_user", "Windows")
                     {
                         SubjectId = "atlas_user",
                         IdentityProvider = "Windows",

--- a/Fabric.Authorization.UnitTests/Users/UsersModuleTests.cs
+++ b/Fabric.Authorization.UnitTests/Users/UsersModuleTests.cs
@@ -51,7 +51,8 @@ namespace Fabric.Authorization.UnitTests.Users
                 new Claim(Claims.Scope, Scopes.ReadScope),
                 new Claim(Claims.ClientId, existingClient.Id),
                 new Claim(JwtClaimTypes.Role, group),
-                new Claim(Claims.Sub, existingUser.SubjectId)
+                new Claim(Claims.Sub, existingUser.SubjectId),
+                new Claim(Claims.IdentityProvider, existingUser.IdentityProvider)
             );
             var result = usersModule.Get("/user/permissions", with =>
                 {
@@ -90,7 +91,8 @@ namespace Fabric.Authorization.UnitTests.Users
                 new Claim(Claims.Scope, Scopes.ReadScope),
                 new Claim(Claims.ClientId, existingClient.Id),
                 new Claim(JwtClaimTypes.Role, @"Fabric\Health Catalyst Admin"),
-                new Claim(Claims.Sub, existingUser.SubjectId)
+                new Claim(Claims.Sub, existingUser.SubjectId),
+                new Claim(Claims.IdentityProvider, existingUser.IdentityProvider )
             );
             var result = usersModule.Get("/user/permissions").Result;
             AssertOk(result, 3);

--- a/Fabric.Authorization.UnitTests/Users/UsersModuleTests.cs
+++ b/Fabric.Authorization.UnitTests/Users/UsersModuleTests.cs
@@ -164,10 +164,8 @@ namespace Fabric.Authorization.UnitTests.Users
 
             _existingUsers = new List<User>
             {
-                new User
+                new User("user123", "Windows")
                 {
-                    Id = "user123",
-                    SubjectId = "user123",
                     Groups = new List<string>
                     {
                         customGroup.Name


### PR DESCRIPTION
get identity provider from claims when finding permissions for a user
when searching for user use the userid (subjectid:identityprovider)
added identityprovider to endpoint for getting a users groups
