### PR TITLE
remove content type header for get requests

### DIFF
--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -82,6 +82,7 @@ namespace Fabric.Authorization.API
                         container.Resolve<IResponseNegotiator>(),
                         _env));
 
+            pipelines.BeforeRequest += ctx => RequestHooks.RemoveContentTypeHeaderForGet(ctx);
             pipelines.BeforeRequest += ctx => RequestHooks.SetDefaultVersionInUrl(ctx);
 
             pipelines.AfterRequest += ctx =>

--- a/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using Fabric.Authorization.API;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.API.Models;
@@ -40,7 +38,8 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                         new Claim(Claims.Scope, Scopes.ReadScope),
                         new Claim(Claims.Scope, Scopes.WriteScope),
                     }, "testprincipal"));
-                    pipelines.BeforeRequest += (ctx) => RequestHooks.SetDefaultVersionInUrl(ctx);
+                    pipelines.BeforeRequest += ctx => RequestHooks.RemoveContentTypeHeaderForGet(ctx);
+                    pipelines.BeforeRequest += ctx => RequestHooks.SetDefaultVersionInUrl(ctx);
                 });
             }, withDefaults => withDefaults.HostName("testhost"));
         }
@@ -206,5 +205,20 @@ namespace Fabric.Authorization.IntegrationTests.Modules
 
             Assert.Equal(HttpStatusCode.NotFound, delete.StatusCode);
         }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public void TestGetClient_ContentTypeHeaderSet_Success()
+        {
+            var get = this.Browser.Get($"/clients/Client1", with =>
+                {
+                    with.HttpRequest();
+                    with.Header("Accept", "application/json");
+                    with.Header("Content-Type", "application/json");
+                }).Result;
+
+            Assert.Equal(HttpStatusCode.NotFound, get.StatusCode);
+        }
+                
     }
 }

--- a/Fabric.Authorization.UnitTests/ModuleTestsBase.cs
+++ b/Fabric.Authorization.UnitTests/ModuleTestsBase.cs
@@ -149,8 +149,9 @@ namespace Fabric.Authorization.UnitTests
         {
             return new Browser(CreateBootstrapper(claims), withDefaults =>
             {
-                withDefaults.Accept("application/json");
+                withDefaults.Accept("application/json");                
                 withDefaults.HostName("testhost");
+                withDefaults.Header("Content-Type", "application/json");
             });
         }
 
@@ -170,6 +171,7 @@ namespace Fabric.Authorization.UnitTests
             configurableBootstrapperConfigurator.RequestStartup((container, pipeline, context) =>
             {
                 context.CurrentUser = new TestPrincipal(claims);
+                pipeline.BeforeRequest += ctx => RequestHooks.RemoveContentTypeHeaderForGet(ctx);
                 pipeline.BeforeRequest += ctx => RequestHooks.SetDefaultVersionInUrl(ctx);
             });
             return configurableBootstrapperConfigurator;


### PR DESCRIPTION
the model binding breaks in nancy if there is a content-type header set for get requests. i added a request hook to remove it if its present