### PR TITLE
Added code to create a user when initializing the CouchDB database.

### DIFF
--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -134,6 +134,7 @@ namespace Fabric.Authorization.API
                 container.Register<IDocumentDbService, CouchDbAccessService>("inner");
                 var dbAccessService = container.Resolve<CouchDbAccessService>();
                 dbAccessService.Initialize().Wait();
+                dbAccessService.SetupDefaultUser().Wait();
                 dbAccessService.AddViews("roles", CouchDbRoleStore.GetViews()).Wait();
                 dbAccessService.AddViews("permissions", CouchDbPermissionStore.GetViews()).Wait();
             }


### PR DESCRIPTION
This will lock down the individual authorization database so only the server admin or the created user can access it.