### PR TITLE
enhance model validation so we can return different status codes 

### DIFF
--- a/Fabric.Authorization.API/Models/ModelExtensions.cs
+++ b/Fabric.Authorization.API/Models/ModelExtensions.cs
@@ -249,7 +249,7 @@ namespace Fabric.Authorization.API.Models
 
             var error = new Error
             {
-                Message = details.Count > 1 ? "Multiple Errors" : details.FirstOrDefault().Message,
+                Message = details.Count > 1 ? "Multiple Errors" : details.FirstOrDefault()?.Message,
                 Details = details.ToArray()
             };
 

--- a/Fabric.Authorization.API/Models/Search/Validators/IdentitySearchRequestValidator.cs
+++ b/Fabric.Authorization.API/Models/Search/Validators/IdentitySearchRequestValidator.cs
@@ -1,5 +1,8 @@
 ﻿using System;
 using System.Linq;
+
+using Fabric.Authorization.Domain.Validators;
+
 using FluentValidation;
 
 namespace Fabric.Authorization.API.Models.Search.Validators
@@ -17,17 +20,20 @@ namespace Fabric.Authorization.API.Models.Search.Validators
         {
             RuleFor(request => request.ClientId)
                 .NotEmpty()
-                .WithMessage("Please specify client_id for searching.");
+                .WithMessage("Please specify client_id for searching.")
+                .WithState(c => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(request => request.SortKey)
                 .Must(sortKey => string.IsNullOrWhiteSpace(sortKey) ||
                                  ValidSortKeys.Contains(sortKey, StringComparer.OrdinalIgnoreCase))
-                .WithMessage($"sort_key must be one of the following values: {ValidSortKeys}");
+                .WithMessage($"sort_key must be one of the following values: {ValidSortKeys}")
+                .WithState(c => ValidationEnums.ValidationState.InvalidFieldValue);
 
             RuleFor(request => request.SortDirection)
                 .Must(sortDirection => string.IsNullOrWhiteSpace(sortDirection) ||
                                        ValidSortDirections.Contains(sortDirection, StringComparer.OrdinalIgnoreCase))
-                .WithMessage($"sort_dir must be one of the following values: {ValidSortDirections}");
+                .WithMessage($"sort_dir must be one of the following values: {ValidSortDirections}")
+                .WithState(c => ValidationEnums.ValidationState.InvalidFieldValue);
         }
     }
 }

--- a/Fabric.Authorization.API/ModuleExtensions/ModuleValidation.cs
+++ b/Fabric.Authorization.API/ModuleExtensions/ModuleValidation.cs
@@ -1,5 +1,9 @@
 ﻿using System;
+using System.Linq;
+
 using Fabric.Authorization.API.Models;
+using Fabric.Authorization.Domain.Validators;
+
 using FluentValidation.Results;
 using Nancy;
 using Nancy.Extensions;
@@ -19,8 +23,14 @@ namespace Fabric.Authorization.API.ModuleExtensions
         {
             return (context) =>
             {
-                var error = ErrorFactory.CreateError<T>(validationResult, HttpStatusCode.BadRequest);
-                return new JsonResponse(error, new DefaultJsonSerializer(context.Environment), context.Environment){ StatusCode = HttpStatusCode.BadRequest};
+                var statusCode = HttpStatusCode.BadRequest;
+                if (validationResult.Errors.Any(e => e.CustomState.Equals(ValidationEnums.ValidationState.Duplicate)))
+                {
+                    statusCode = HttpStatusCode.Conflict;
+                }
+
+                var error = ErrorFactory.CreateError<T>(validationResult, statusCode);
+                return new JsonResponse(error, new DefaultJsonSerializer(context.Environment), context.Environment){ StatusCode = statusCode };
             };
         }
     }

--- a/Fabric.Authorization.API/ModuleExtensions/ModuleValidation.cs
+++ b/Fabric.Authorization.API/ModuleExtensions/ModuleValidation.cs
@@ -24,7 +24,7 @@ namespace Fabric.Authorization.API.ModuleExtensions
             return (context) =>
             {
                 var statusCode = HttpStatusCode.BadRequest;
-                if (validationResult.Errors.Any(e => e.CustomState.Equals(ValidationEnums.ValidationState.Duplicate)))
+                if (validationResult.Errors.Any(e => e.CustomState != null && e.CustomState.Equals(ValidationEnums.ValidationState.Duplicate)))
                 {
                     statusCode = HttpStatusCode.Conflict;
                 }

--- a/Fabric.Authorization.API/Modules/ClientsModule.cs
+++ b/Fabric.Authorization.API/Modules/ClientsModule.cs
@@ -66,17 +66,9 @@ namespace Fabric.Authorization.API.Modules
                 model => model.TopLevelSecurableItem);
             var incomingClient = clientApiModel.ToClientDomainModel();
             Validate(incomingClient);
-            try
-            {
-                Client client = await _clientService.AddClient(incomingClient);
-                return CreateSuccessfulPostResponse(client.ToClientApiModel());
-            }
-            catch (AlreadyExistsException<Client> ex)
-            {
-                Logger.Error(ex, ex.Message, incomingClient.Id);
-                return CreateFailureResponse($"The specified client with id: {incomingClient.Id} already exists. Please provide a new id.",
-                    HttpStatusCode.Conflict);
-            }
+            
+            Client client = await _clientService.AddClient(incomingClient);
+            return CreateSuccessfulPostResponse(client.ToClientApiModel());
         }
 
         private async Task<dynamic> DeleteClient(dynamic parameters)

--- a/Fabric.Authorization.API/Modules/SecurableItemsModule.cs
+++ b/Fabric.Authorization.API/Modules/SecurableItemsModule.cs
@@ -105,7 +105,7 @@ namespace Fabric.Authorization.API.Modules
             }
             catch (AlreadyExistsException<SecurableItem> ex)
             {
-                Logger.Error(ex, "The posted securable item {@securableItemApiModel} already exists.",
+                Logger.Error(ex, $"Securable item {securableItemApiModel.Name} already exists. Please provide a new name",
                     securableItemApiModel);
                 return CreateFailureResponse(
                     ex.Message,
@@ -139,7 +139,7 @@ namespace Fabric.Authorization.API.Modules
             }
             catch (AlreadyExistsException<SecurableItem> ex)
             {
-                Logger.Error(ex, "The posted securable item {@securableItemApiModel} already exists.",
+                Logger.Error(ex, $"Securable item {securableItemApiModel.Name} already exists. Please provide a new name",
                     securableItemApiModel);
                 return CreateFailureResponse(
                     ex.Message,

--- a/Fabric.Authorization.Domain/Validators/ClientValidator.cs
+++ b/Fabric.Authorization.Domain/Validators/ClientValidator.cs
@@ -24,7 +24,8 @@ namespace Fabric.Authorization.Domain.Validators
             RuleFor(client => client.Id)
                 .Must(BeUnique)
                 .When(client => !string.IsNullOrEmpty(client.Id))
-                .WithMessage("The client Id already exists.");
+                .WithMessage(c => $"Client {c.Id} already exists. Please provide a new client id.")
+                .WithState(c=> ValidationEnums.ValidationState.Duplicate);
 
             RuleFor(client => client.Name)
                 .NotEmpty()

--- a/Fabric.Authorization.Domain/Validators/ClientValidator.cs
+++ b/Fabric.Authorization.Domain/Validators/ClientValidator.cs
@@ -19,7 +19,8 @@ namespace Fabric.Authorization.Domain.Validators
         {
             RuleFor(client => client.Id)
                 .NotEmpty()
-                .WithMessage("Please specify an Id for this client");
+                .WithMessage("Please specify an Id for this client")
+                .WithState(c => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(client => client.Id)
                 .Must(BeUnique)
@@ -29,7 +30,8 @@ namespace Fabric.Authorization.Domain.Validators
 
             RuleFor(client => client.Name)
                 .NotEmpty()
-                .WithMessage("Please specify a Name for this client");
+                .WithMessage("Please specify a Name for this client")
+                .WithState(c => ValidationEnums.ValidationState.MissingRequiredField);
         }
 
         private bool BeUnique(string clientId)

--- a/Fabric.Authorization.Domain/Validators/GroupValidator.cs
+++ b/Fabric.Authorization.Domain/Validators/GroupValidator.cs
@@ -20,15 +20,18 @@ namespace Fabric.Authorization.Domain.Validators
         {
             RuleFor(group => group.Name)
                 .NotEmpty()
-                .WithMessage("Please specify a Name for this Group.");
+                .WithMessage("Please specify a Name for this Group.")
+                .WithState(g => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(group => group.Source)
                 .NotEmpty()
-                .WithMessage("Please specify a Source for this Group.");
+                .WithMessage("Please specify a Source for this Group.")
+                .WithState(g => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(group => group)
                 .Must(BeUnique)
-                .WithMessage("An active group with this groupName already exists. Please specify a different groupName.");
+                .WithMessage(g => $"An active group with groupName {g.Name} already exists. Please provide a new groupName.")
+                .WithState(g => ValidationEnums.ValidationState.Duplicate);
         }
 
         /// <summary>
@@ -40,7 +43,13 @@ namespace Fabric.Authorization.Domain.Validators
         /// <returns>true if supplied group name does not exist on an active group document; otherwise false</returns>
         private bool BeUnique(Group group)
         {
-            return !string.IsNullOrWhiteSpace(group?.Id) && !_groupService.Exists(group?.Id).Result;
+            //if id is null then Name is not set which will be caught in a different validator
+            if (group.Id == null)
+            {
+                return true;
+            }
+
+            return !_groupService.Exists(group?.Id).Result;
         }
     }
 }

--- a/Fabric.Authorization.Domain/Validators/PermissionValidator.cs
+++ b/Fabric.Authorization.Domain/Validators/PermissionValidator.cs
@@ -20,22 +20,26 @@ namespace Fabric.Authorization.Domain.Validators
         {
             RuleFor(permission => permission.Grain)
                 .NotEmpty()
-                .WithMessage("Please specify a Grain for this permission");
+                .WithMessage("Please specify a Grain for this permission")
+                .WithState(p => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(permission => permission.SecurableItem)
                 .NotEmpty()
-                .WithMessage("Please specify a SecurableItem for this permission");
+                .WithMessage("Please specify a SecurableItem for this permission")
+                .WithState(p => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(permission => permission.Name)
                 .NotEmpty()
-                .WithMessage("Please specify a Name for this permission");
+                .WithMessage("Please specify a Name for this permission")
+                .WithState(p => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(permission => permission)
                 .Must(BeUnique)
                 .When(permission => !string.IsNullOrEmpty(permission.Grain)
                                     && !string.IsNullOrEmpty(permission.SecurableItem)
                                     && !string.IsNullOrEmpty(permission.Name))
-                .WithMessage("The permission already exists");
+                .WithMessage(p => $"Permission {p.Name} already exists. Please provide a new name")
+                .WithState(p => ValidationEnums.ValidationState.Duplicate);
         }
 
         private bool BeUnique(Permission permission)

--- a/Fabric.Authorization.Domain/Validators/RoleValidator.cs
+++ b/Fabric.Authorization.Domain/Validators/RoleValidator.cs
@@ -20,22 +20,26 @@ namespace Fabric.Authorization.Domain.Validators
         {
             RuleFor(role => role.Grain)
                 .NotEmpty()
-                .WithMessage("Please specify a Grain for this role");
+                .WithMessage("Please specify a Grain for this role")
+                .WithState(r => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(role => role.SecurableItem)
                 .NotEmpty()
-                .WithMessage("Please specify a SecurableItem for this role");
+                .WithMessage("Please specify a SecurableItem for this role")
+                .WithState(r => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(role => role.Name)
                 .NotEmpty()
-                .WithMessage("Please specify a Name for this role");
+                .WithMessage("Please specify a Name for this role")
+                .WithState(r => ValidationEnums.ValidationState.MissingRequiredField);
 
             RuleFor(role => role)
                 .Must(BeUnique)
                 .When(role => !string.IsNullOrEmpty(role.Grain)
                               && !string.IsNullOrEmpty(role.SecurableItem)
                               && !string.IsNullOrEmpty(role.Name))
-                .WithMessage("The role already exists");
+                .WithMessage(r => $"Role {r.Name} already exists. Please provide a new name.")
+                .WithState(r => ValidationEnums.ValidationState.Duplicate);
         }
 
         private bool BeUnique(Role role)

--- a/Fabric.Authorization.Domain/Validators/SecurableItemValidator.cs
+++ b/Fabric.Authorization.Domain/Validators/SecurableItemValidator.cs
@@ -17,7 +17,10 @@ namespace Fabric.Authorization.Domain.Validators
         {
             RuleFor(item => item.Name)
                 .NotEmpty()
-                .WithMessage("Please specifiy a Name for the SecurableItem");
+                .WithMessage("Please specifiy a Name for the SecurableItem")
+                .WithState(s => ValidationEnums.ValidationState.MissingRequiredField);
+
+
         }
     }
 }

--- a/Fabric.Authorization.Domain/Validators/ValidationEnums.cs
+++ b/Fabric.Authorization.Domain/Validators/ValidationEnums.cs
@@ -9,7 +9,8 @@ namespace Fabric.Authorization.Domain.Validators
         public enum ValidationState
         {
             Duplicate,
-            MissingRequiredField
+            MissingRequiredField,
+            InvalidFieldValue
         }
     }
 }

--- a/Fabric.Authorization.Domain/Validators/ValidationEnums.cs
+++ b/Fabric.Authorization.Domain/Validators/ValidationEnums.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fabric.Authorization.Domain.Validators
+{
+    public class ValidationEnums
+    {
+        public enum ValidationState
+        {
+            Duplicate,
+            MissingRequiredField
+        }
+    }
+}

--- a/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBGroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBGroupsTests.cs
@@ -32,7 +32,7 @@ namespace Fabric.Authorization.IntegrationTests.CouchDB
                 with.Header("Accept", "application/json");
             }).Result;
 
-            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
         }
 
         [Fact]

--- a/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
+++ b/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
@@ -41,8 +41,8 @@ namespace Fabric.Authorization.IntegrationTests
             ICouchDbSettings config = new CouchDbSettings()
             {
                 DatabaseName = "integration-" + DateTime.UtcNow.Ticks,
-                Username = "admin",
-                Password = "admin",
+                Username = "",
+                Password = "",
                 Server = "http://127.0.0.1:5984"
             };
 

--- a/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
+++ b/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
@@ -41,8 +41,8 @@ namespace Fabric.Authorization.IntegrationTests
             ICouchDbSettings config = new CouchDbSettings()
             {
                 DatabaseName = "integration-" + DateTime.UtcNow.Ticks,
-                Username = "",
-                Password = "",
+                Username = "admin",
+                Password = "admin",
                 Server = "http://127.0.0.1:5984"
             };
 

--- a/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
@@ -175,7 +175,10 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 with.JsonBody(clientToAdd);
             }).Result;
 
-            Assert.Equal(HttpStatusCode.BadRequest, postResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.Conflict, postResponse.StatusCode);
+            Assert.Contains(
+                $"Client {Id} already exists. Please provide a new client id",
+                postResponse.Body.AsString());
         }
 
         [Theory]

--- a/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
@@ -334,7 +334,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         [DisplayTestMethodName]
         [InlineData("RepeatedGroup1")]
         [InlineData("RepeatedGroup2")]
-        public void AddGroup_AlreadyExists_BadRequest(string groupName)
+        public void AddGroup_AlreadyExists_Conflict(string groupName)
         {
             Browser.Post("/groups", with =>
             {
@@ -351,7 +351,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 with.Header("Accept", "application/json");
             }).Result;
 
-            Assert.Equal(HttpStatusCode.BadRequest, postResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.Conflict, postResponse.StatusCode);
         }
 
         [Theory]

--- a/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
@@ -217,7 +217,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 with.FormValue("Name", permission);
             }).Result;
 
-            Assert.Equal(HttpStatusCode.BadRequest, postResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.Conflict, postResponse.StatusCode);
         }
 
         [Theory]

--- a/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
@@ -222,7 +222,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 with.FormValue("Id", id);
             }).Result;
 
-            Assert.Equal(HttpStatusCode.BadRequest, postResponse.StatusCode);
+            Assert.Equal(HttpStatusCode.Conflict, postResponse.StatusCode);
         }
 
         [Theory]

--- a/Fabric.Authorization.UnitTests/Clients/ClientsModuleTests.cs
+++ b/Fabric.Authorization.UnitTests/Clients/ClientsModuleTests.cs
@@ -142,6 +142,17 @@ namespace Fabric.Authorization.UnitTests.Clients
         }
 
         [Fact]
+        public void AddClient_DuplicateReturnsConflict()
+        {
+            var clientsModule = CreateBrowser(new Claim(Claims.Scope, Scopes.ManageClientsScope),
+                new Claim(Claims.Scope, Scopes.WriteScope));
+            var clientToPost =
+                new ClientApiModel { Id = "sample-fabric-app", Name = "Sample Fabric Client Application" };
+            var result = clientsModule.Post("/clients", with => with.JsonBody(clientToPost)).Result;
+            Assert.Equal(HttpStatusCode.Conflict, result.StatusCode);
+        }
+
+        [Fact]
         public void AddClient_PreventsOverposting()
         {
             var clientsModule = CreateBrowser(new Claim(Claims.Scope, Scopes.ManageClientsScope),
@@ -171,6 +182,7 @@ namespace Fabric.Authorization.UnitTests.Clients
             Assert.True(string.IsNullOrEmpty(newClient.CreatedBy));
             Assert.True(string.IsNullOrEmpty(newClient.ModifiedBy));
         }
+
 
         [Fact]
         public void DeleteClient_Successful()
@@ -207,6 +219,7 @@ namespace Fabric.Authorization.UnitTests.Clients
             Assert.Contains(nonexistentId, error.Message);
         }
 
+      
         protected override ConfigurableBootstrapper.ConfigurableBootstrapperConfigurator ConfigureBootstrapper(ConfigurableBootstrapper configurableBootstrapper, params Claim[] claims)
         {
             return base.ConfigureBootstrapper(configurableBootstrapper, claims)
@@ -219,8 +232,7 @@ namespace Fabric.Authorization.UnitTests.Clients
         {
             new object[] { new Client{ Id = null, Name = null}, 2},
             new object[] { new Client{ Id = string.Empty, Name = string.Empty}, 2},
-            new object[] { new Client{ Id = "newapp", Name = string.Empty}, 1},
-            new object[] { new Client{ Id = "sample-fabric-app", Name = "sample-fabric-app" }, 1}
+            new object[] { new Client{ Id = "newapp", Name = string.Empty}, 1},            
         };
     }
 }

--- a/Fabric.Authorization.UnitTests/Permissions/PermissionsModuleTests.cs
+++ b/Fabric.Authorization.UnitTests/Permissions/PermissionsModuleTests.cs
@@ -137,7 +137,7 @@ namespace Fabric.Authorization.UnitTests.Permissions
                     SecurableItem = existingPermission.SecurableItem,
                     Name = existingPermission.Name
                 })).Result;
-            Assert.Equal(HttpStatusCode.BadRequest, actual.StatusCode);
+            Assert.Equal(HttpStatusCode.Conflict, actual.StatusCode);
         }
 
         [Fact]

--- a/Fabric.Authorization.UnitTests/SecurableItems/SecurableItemsModuleTests.cs
+++ b/Fabric.Authorization.UnitTests/SecurableItems/SecurableItemsModuleTests.cs
@@ -246,9 +246,9 @@ namespace Fabric.Authorization.UnitTests.SecurableItems
         public static IEnumerable<object[]> BadRequestData => new[]
         {
             new object[] { new SecurableItemApiModel{ Name = null}, 1, false},
-            new object[] { new SecurableItemApiModel{ Name = string.Empty}, 1, false},
+            new object[] { new SecurableItemApiModel{ Name = string.Empty}, 1, false},            
             new object[] { new SecurableItemApiModel{ Name = null}, 1, true},
-            new object[] { new SecurableItemApiModel{ Name = string.Empty}, 1, true}
+            new object[] { new SecurableItemApiModel{ Name = string.Empty}, 1, true}            
         };
 
         public static IEnumerable<object[]> BadScopes => new[]


### PR DESCRIPTION
added a CustomState to the model validation errors so when we are building the validation response for the client we can return a 409 if there is an attempt to add a duplicate resource 