### PR TITLE
moved db specific stuff out of the GroupService class and into the store implementations

### DIFF
--- a/Fabric.Authorization.Domain/Stores/CouchDB/CouchDBGroupStore.cs
+++ b/Fabric.Authorization.Domain/Stores/CouchDB/CouchDBGroupStore.cs
@@ -11,14 +11,20 @@ namespace Fabric.Authorization.Domain.Stores.CouchDB
 {
     public class CouchDbGroupStore : FormattableIdentifierStore<string, Group>, IGroupStore
     {
+        private readonly IRoleStore _roleStore;
+        private readonly IUserStore _userStore;
         private const string IdDelimiter = "-:-:";
 
         public CouchDbGroupStore(
             IDocumentDbService dbService,
             ILogger logger,
             IEventContextResolverService eventContextResolverService,
-            IIdentifierFormatter identifierFormatter) : base(dbService, logger, eventContextResolverService, identifierFormatter)
+            IIdentifierFormatter identifierFormatter, 
+            IRoleStore roleStore,
+            IUserStore userStore) : base(dbService, logger, eventContextResolverService, identifierFormatter)
         {
+            _roleStore = roleStore;
+            _userStore = userStore;
         }
 
         public override async Task<Group> Add(Group group)
@@ -98,6 +104,32 @@ namespace Fabric.Authorization.Domain.Stores.CouchDB
         private string GetGroupIdPrefix(string id)
         {
             return $"{DocumentKeyPrefix}{FormatId(id)}{IdDelimiter}";
+        }
+
+        public async Task<Group> AddRoleToGroup(Group group, Role role)
+        {
+            group.Roles.Add(role);
+            role.Groups.Add(group.Name);
+
+            await _roleStore.Update(role);
+            await Update(group);
+
+            return group;
+        }
+
+        public Task<Group> DeleteRoleFromGroup(string groupName, Guid roleId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Group> AddUserToGroup(string groupName, string subjectId, string identityProvider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Fabric.Authorization.Domain/Stores/IGroupStore.cs
+++ b/Fabric.Authorization.Domain/Stores/IGroupStore.cs
@@ -1,9 +1,14 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Fabric.Authorization.Domain.Models;
 
 namespace Fabric.Authorization.Domain.Stores
 {
     public interface IGroupStore : IGenericStore<string, Group>
     {
+        Task<Group> AddRoleToGroup(Group @group, Role role);
+        Task<Group> DeleteRoleFromGroup(string groupName, Guid roleId);
+        Task<Group> AddUserToGroup(string groupName, string subjectId, string identityProvider);
+        Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider);
     }
 }

--- a/Fabric.Authorization.Domain/Stores/IGroupStore.cs
+++ b/Fabric.Authorization.Domain/Stores/IGroupStore.cs
@@ -6,7 +6,7 @@ namespace Fabric.Authorization.Domain.Stores
 {
     public interface IGroupStore : IGenericStore<string, Group>
     {
-        Task<Group> AddRoleToGroup(Group @group, Role role);
+        Task<Group> AddRoleToGroup(string groupName, Guid roleId);
         Task<Group> DeleteRoleFromGroup(string groupName, Guid roleId);
         Task<Group> AddUserToGroup(string groupName, string subjectId, string identityProvider);
         Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider);

--- a/Fabric.Authorization.Domain/Stores/InMemory/InMemoryGroupStore.cs
+++ b/Fabric.Authorization.Domain/Stores/InMemory/InMemoryGroupStore.cs
@@ -1,15 +1,25 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Fabric.Authorization.Domain.Exceptions;
 using Fabric.Authorization.Domain.Models;
+using Fabric.Authorization.Domain.Stores.Services;
 
 namespace Fabric.Authorization.Domain.Stores.InMemory
 {
     public class InMemoryGroupStore : InMemoryFormattableIdentifierStore<Group>, IGroupStore
     {
+        private readonly IRoleStore _roleStore;
+        private readonly IUserStore _userStore;
+
         [Obsolete]
-        public InMemoryGroupStore(IIdentifierFormatter identifierFormatter) : base(identifierFormatter)
+        public InMemoryGroupStore(IIdentifierFormatter identifierFormatter, 
+            IRoleStore roleStore,
+            IUserStore userStore) 
+            : base(identifierFormatter)
         {
+            _roleStore = roleStore;
+            _userStore = userStore;
             var group1 = new Group
             {
                 Id = Guid.NewGuid().ToString(),
@@ -77,6 +87,109 @@ namespace Fabric.Authorization.Domain.Stores.InMemory
         {
             var formattedId = FormatId(id);
             return await base.Exists(formattedId) && !Dictionary[formattedId].IsDeleted;
+        }
+
+        public async Task<Group> AddRoleToGroup(string groupName, Guid roleId)
+        {
+            var group = await Get(groupName);
+            var role = await _roleStore.Get(roleId);
+
+            if (group.Roles.Any(r => r.Id == roleId)
+                || role.Groups.Any(g => string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new AlreadyExistsException<Role>($"Role {role.Name} already exists for group {group.Name}. Please provide a new role id.");
+            }
+
+            group.Roles.Add(role);
+            role.Groups.Add(groupName);
+
+            await _roleStore.Update(role);
+            await Update(group);
+
+            return group;
+        }
+
+        public async Task<Group> DeleteRoleFromGroup(string groupName, Guid roleId)
+        {
+            var group = await Get(groupName);
+            var role = await _roleStore.Get(roleId);
+
+            var groupRole = group.Roles.FirstOrDefault(r => r.Id == roleId);
+            if (groupRole != null)
+            {
+                group.Roles.Remove(groupRole);
+            }
+
+            if (role.Groups.Any(g => string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
+            {
+                role.Groups.Remove(groupName);
+            }
+
+            await _roleStore.Update(role);
+            await Update(group);
+            return group;
+        }
+
+        public async Task<Group> AddUserToGroup(string groupName, string subjectId, string identityProvider)
+        {
+            var group = await Get(groupName);
+
+            //only add users to a custom group
+            if (!string.Equals(group.Source, GroupConstants.CustomSource, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new BadRequestException<Group>("The group to which you are attempting to add a user is not specified as a 'Custom' group. Only 'Custom' groups allow associations with users.");
+            }
+
+            User user;
+            try
+            {
+                user = await _userStore.Get($"{subjectId}:{identityProvider}");
+            }
+            catch (NotFoundException<User>)
+            {
+                user = await _userStore.Add(new User(subjectId, identityProvider));
+            }
+
+            if (!group.Users.Any(u =>
+                string.Equals(u.SubjectId, subjectId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(u.IdentityProvider, identityProvider, StringComparison.OrdinalIgnoreCase)))
+            {
+                group.Users.Add(user);
+            }
+            else
+            {
+                throw new AlreadyExistsException<Group>($"The user {identityProvider}:{subjectId} has already been added to the group {groupName}.");
+            }
+
+            if (user.Groups.All(g => !string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
+            {
+                user.Groups.Add(groupName);
+            }
+
+            await _userStore.Update(user);
+            await Update(group);
+            return group;
+        }
+
+        public async Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider)
+        {
+            var group = await Get(groupName);
+            var user = await _userStore.Get($"{subjectId}:{identityProvider}");
+
+            var groupUser = group.Users.FirstOrDefault(u => u.Id == user.Id);
+            if (groupUser != null)
+            {
+                group.Users.Remove(groupUser);
+            }
+
+            if (user.Groups.Any(g => string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
+            {
+                user.Groups.Remove(groupName);
+            }
+
+            await _userStore.Update(user);
+            await Update(group);
+            return group;
         }
     }
 }

--- a/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
+++ b/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
@@ -94,13 +94,8 @@ namespace Fabric.Authorization.Domain.Stores.Services
             {
                 throw new AlreadyExistsException<Role>($"Role {role.Name} already exists for group {group.Name}. Please provide a new role id.");
             }
-            
-            group.Roles.Add(role);
-            role.Groups.Add(groupName);
 
-            await _roleStore.Update(role);
-            await _groupStore.Update(group);
-            return group;
+           return await _groupStore.AddRoleToGroup(group, role);
         }
 
         public async Task<Group> DeleteRoleFromGroup(string groupName, Guid roleId)

--- a/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
+++ b/Fabric.Authorization.Domain/Stores/Services/GroupService.cs
@@ -28,19 +28,13 @@ namespace Fabric.Authorization.Domain.Stores.Services
         };
 
         private readonly IGroupStore _groupStore;
-        private readonly IRoleStore _roleStore;
-        private readonly IUserStore _userStore;
         private readonly RoleService _roleService;
 
         public GroupService(
             IGroupStore groupStore,
-            IRoleStore roleStore,
-            IUserStore userStore,
             RoleService roleService)
         {
-            _groupStore = groupStore ?? throw new ArgumentNullException(nameof(groupStore));
-            _roleStore = roleStore ?? throw new ArgumentNullException(nameof(roleStore));
-            _userStore = userStore ?? throw new ArgumentNullException(nameof(userStore));
+            _groupStore = groupStore ?? throw new ArgumentNullException(nameof(groupStore));          
             _roleService = roleService ?? throw new ArgumentNullException(nameof(roleService));
         }
 
@@ -86,99 +80,22 @@ namespace Fabric.Authorization.Domain.Stores.Services
 
         public async Task<Group> AddRoleToGroup(string groupName, Guid roleId)
         {
-            var group = await _groupStore.Get(groupName);
-            var role = await _roleStore.Get(roleId);
-
-            if (group.Roles.Any(r => r.Id == roleId)
-                || role.Groups.Any(g => string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
-            {
-                throw new AlreadyExistsException<Role>($"Role {role.Name} already exists for group {group.Name}. Please provide a new role id.");
-            }
-
-           return await _groupStore.AddRoleToGroup(group, role);
+            return await _groupStore.AddRoleToGroup(groupName, roleId);
         }
 
         public async Task<Group> DeleteRoleFromGroup(string groupName, Guid roleId)
         {
-            var group = await _groupStore.Get(groupName);
-            var role = await _roleStore.Get(roleId);
-
-            var groupRole = group.Roles.FirstOrDefault(r => r.Id == roleId);
-            if (groupRole != null)
-            {
-                group.Roles.Remove(groupRole);
-            }
-
-            if (role.Groups.Any(g => string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
-            {
-                role.Groups.Remove(groupName);
-            }
-
-            await _roleStore.Update(role);
-            await _groupStore.Update(group);
-            return group;
+            return await _groupStore.DeleteRoleFromGroup(groupName, roleId);
         }
 
         public async Task<Group> AddUserToGroup(string groupName, string subjectId, string identityProvider)
         {
-            var group = await _groupStore.Get(groupName);
-
-            //only add users to a custom group
-            if (!string.Equals(group.Source, GroupConstants.CustomSource, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new BadRequestException<Group>("The group to which you are attempting to add a user is not specified as a 'Custom' group. Only 'Custom' groups allow associations with users.");
-            }
-
-            User user;
-            try
-            {
-                user = await _userStore.Get($"{subjectId}:{identityProvider}");
-            }
-            catch (NotFoundException<User>)
-            {
-                user = await _userStore.Add(new User(subjectId, identityProvider));
-            }
-
-            if (!group.Users.Any(u =>
-                string.Equals(u.SubjectId, subjectId, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(u.IdentityProvider, identityProvider, StringComparison.OrdinalIgnoreCase)))
-            {
-                group.Users.Add(user);
-            }
-            else
-            {
-                throw new AlreadyExistsException<Group>($"The user {identityProvider}:{subjectId} has already been added to the group {groupName}.");
-            }
-
-            if (user.Groups.All(g => !string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
-            {
-                user.Groups.Add(groupName);
-            }
-
-            await _userStore.Update(user);
-            await _groupStore.Update(group);
-            return group;
+            return await _groupStore.AddUserToGroup(groupName, subjectId, identityProvider);
         }
 
         public async Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider)
         {
-            var group = await _groupStore.Get(groupName);
-            var user = await _userStore.Get($"{subjectId}:{identityProvider}");
-
-            var groupUser = group.Users.FirstOrDefault(u => u.Id == user.Id);
-            if (groupUser != null)
-            {
-                group.Users.Remove(groupUser);
-            }
-
-            if (user.Groups.Any(g => string.Equals(g, groupName, StringComparison.OrdinalIgnoreCase)))
-            {
-                user.Groups.Remove(groupName);
-            }
-
-            await _userStore.Update(user);
-            await _groupStore.Update(group);
-            return group;
+           return await _groupStore.DeleteUserFromGroup(groupName, subjectId, identityProvider);
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
@@ -3,11 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Fabric.Authorization.Domain.Exceptions;
-using Fabric.Authorization.Domain.Models;
 using Fabric.Authorization.Domain.Stores;
+using Fabric.Authorization.Domain.Stores.Services;
+using Fabric.Authorization.Persistence.SqlServer.EntityModels;
 using Fabric.Authorization.Persistence.SqlServer.Mappers;
 using Fabric.Authorization.Persistence.SqlServer.Services;
 using Microsoft.EntityFrameworkCore;
+using Group = Fabric.Authorization.Domain.Models.Group;
+using Role = Fabric.Authorization.Domain.Models.Role;
 
 namespace Fabric.Authorization.Persistence.SqlServer.Stores
 {
@@ -112,6 +115,154 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
                                            && !g.IsDeleted);
 
             return group != null;
+        }
+
+        public async Task<Group> AddRoleToGroup(string groupName, Guid roleId)
+        {           
+            var group = await _authorizationDbContext.Groups
+                .SingleOrDefaultAsync(g => g.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase));
+
+            if (group == null)
+            {
+                throw new NotFoundException<Group>($"Could not find {typeof(Group).Name} entity with ID {groupName}");
+            }
+
+            var role = await _authorizationDbContext.Roles
+                .SingleOrDefaultAsync(r => r.RoleId.Equals(roleId));
+
+            if (role == null)
+            {
+                throw new NotFoundException<Role>($"Could not find {typeof(Role).Name} entity with ID {roleId}");
+            }
+         
+            if (group.GroupRoles.SingleOrDefault(gr => gr.RoleId.Equals(role.Id)) != null)
+            {
+                throw new AlreadyExistsException<Role>($"Role {role.Name} already exists for group {group.Name}. Please provide a new role id.");
+            }
+
+            var groupRole = new GroupRole
+            {
+                GroupId = group.Id,
+                RoleId = role.Id
+            };
+            group.GroupRoles.Add(groupRole);
+            _authorizationDbContext.GroupRoles.Add(groupRole);
+
+            var groupModel = group.ToModel();
+            return groupModel;
+        }
+
+        public async Task<Group> DeleteRoleFromGroup(string groupName, Guid roleId)
+        {
+            var group = await _authorizationDbContext.Groups
+                .Include(g => g.GroupRoles)
+                .SingleOrDefaultAsync(g => g.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase));
+
+            if (group == null)
+            {
+                throw new NotFoundException<Group>($"Could not find {typeof(Group).Name} entity with ID {groupName}");
+            }
+
+            var role = await _authorizationDbContext.Roles
+                .SingleOrDefaultAsync(r => r.RoleId.Equals(roleId));
+
+            if (role == null)
+            {
+                throw new NotFoundException<Role>($"Could not find {typeof(Role).Name} entity with ID {roleId}");
+            }
+
+            var groupRoleToRemove = group.GroupRoles.SingleOrDefault(r => r.RoleId.Equals(role.Id));
+
+            if (groupRoleToRemove != null)
+            {
+                groupRoleToRemove.IsDeleted = true;
+                group.GroupRoles.Remove(groupRoleToRemove);
+                _authorizationDbContext.GroupRoles.Update(groupRoleToRemove);
+                await _authorizationDbContext.SaveChangesAsync();
+            }
+
+            var groupModel = group.ToModel();
+            return groupModel;
+        }
+
+        public async Task<Group> AddUserToGroup(string groupName, string subjectId, string identityProvider)
+        {
+            var group = await _authorizationDbContext.Groups
+                .Include(g => g.GroupUsers)
+                .SingleOrDefaultAsync(g =>
+                    g.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase));
+
+            if (group == null)
+            {
+                throw new NotFoundException<Group>($"Could not find {typeof(Group).Name} entity with ID {groupName}");
+            }
+
+            //only add users to a custom group
+            if (!string.Equals(group.Source, GroupConstants.CustomSource, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new BadRequestException<Group>("The group to which you are attempting to add a user is not specified as a 'Custom' group. Only 'Custom' groups allow associations with users.");
+            }
+
+            //see if user exists and if not then add the user 
+            var user = await _authorizationDbContext.Users.SingleOrDefaultAsync(u =>
+                u.SubjectId.Equals(subjectId, StringComparison.OrdinalIgnoreCase)
+                && u.IdentityProvider.Equals(identityProvider, StringComparison.OrdinalIgnoreCase));
+
+            if (user == null)
+            {
+                user = new User
+                {
+                    SubjectId = subjectId,
+                    IdentityProvider = identityProvider
+                };
+                _authorizationDbContext.Users.Add(user);
+                await _authorizationDbContext.SaveChangesAsync();
+            }
+
+            //check if user already belongs to the group
+            if (!group.GroupUsers.Any(u => u.UserId.Equals(user.Id)))
+            {
+                group.GroupUsers.Add(new GroupUser
+                {
+                    GroupId = group.Id,
+                    UserId = user.Id
+                });
+
+                await _authorizationDbContext.SaveChangesAsync();
+            }
+            else
+            {
+                throw new AlreadyExistsException<Group>(
+                    $"The user {identityProvider}:{subjectId} has already been added to the group {groupName}.");
+            }
+
+            return group.ToModel();
+        }
+
+        public async Task<Group> DeleteUserFromGroup(string groupName, string subjectId, string identityProvider)
+        {
+            var group = await _authorizationDbContext.Groups
+                .Include(g => g.GroupUsers)
+                .ThenInclude(gu => gu.User)
+                .SingleOrDefaultAsync(g => g.Name.Equals(groupName, StringComparison.OrdinalIgnoreCase));
+
+            if (group == null)
+            {
+                throw new NotFoundException<Group>($"Could not find {typeof(Group).Name} entity with ID {groupName}");
+            }
+
+            var userInGroup = group.GroupUsers.SingleOrDefault(gu =>
+                gu.User.SubjectId.Equals(subjectId, StringComparison.OrdinalIgnoreCase)
+                && gu.User.IdentityProvider.Equals(identityProvider, StringComparison.OrdinalIgnoreCase));
+
+            if (userInGroup != null)
+            {
+                userInGroup.IsDeleted = true;
+                group.GroupUsers.Remove(userInGroup);
+                await _authorizationDbContext.SaveChangesAsync();
+            }
+
+            return group.ToModel();
         }
     }
 }

--- a/Fabric.Authorization.UnitTests/Search/IdentitySearchServiceTests.cs
+++ b/Fabric.Authorization.UnitTests/Search/IdentitySearchServiceTests.cs
@@ -177,9 +177,7 @@ namespace Fabric.Authorization.UnitTests.Search
             _clientService = new ClientService(_mockClientStore.Create());
             _roleService = new RoleService(_mockRoleStore.Create(), _mockPermissionStore.Create(), _clientService);
             _groupService = new GroupService(
-                _mockGroupStore.Create(),
-                _mockRoleStore.Create(),
-                new Mock<IUserStore>().Object,
+                _mockGroupStore.Create(),               
                 _roleService);
         }
 


### PR DESCRIPTION
one thing about this approach is i had to move all the code out of the service and into the store methods. the service class basically becomes a pass through. this is because the store methods return domain models and i did not want to have to query again for entities in the sql server store implementation. we can discuss tomorrow morning