### PR TITLE
Add a StorageProvider config so we can switch between more than two storage providers.

### DIFF
--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -157,11 +157,12 @@ namespace Fabric.Authorization.API
                     dbAccessService.AddViews("permissions", CouchDbPermissionStore.GetViews()).Wait();
                     break;
                 case StorageProviders.SqlServer:
-                    break;
-                    
+                    throw new ArgumentException("The SqlServer implementation has not been implemented yet.");
+                default:
+                    throw new ConfigurationException($"Invalid configuration for StorageProvider: {appConfig.StorageProvider}. Valid storage providers are: {StorageProviders.InMemory}, {StorageProviders.CouchDb}, {StorageProviders.SqlServer}");
             }
         }
-        
+
         private void ConfigureRequestDataStores(TinyIoCContainer container, IAppConfiguration appConfig)
         {
             switch (appConfig.StorageProvider)
@@ -172,7 +173,9 @@ namespace Fabric.Authorization.API
                     container.RegisterCouchDbStores(_appConfig, _loggingLevelSwitch);
                     break;
                 case StorageProviders.SqlServer:
-                    break;
+                    throw new ArgumentException("The SqlServer implementation has not been implemented yet.");
+                default:
+                    throw new ConfigurationException($"Invalid configuration for StorageProvider: {appConfig.StorageProvider}. Valid storage providers are: {StorageProviders.InMemory}, {StorageProviders.CouchDb}, {StorageProviders.SqlServer}");
             }
         }
 
@@ -183,5 +186,5 @@ namespace Fabric.Authorization.API
             nancyConventions.StaticContentsConventions.Add(
                 StaticContentConventionBuilder.AddDirectory("/swagger"));
         }
-    }    
+    }
 }

--- a/Fabric.Authorization.API/Configuration/AppConfiguration.cs
+++ b/Fabric.Authorization.API/Configuration/AppConfiguration.cs
@@ -5,7 +5,6 @@ namespace Fabric.Authorization.API.Configuration
     public class AppConfiguration : IAppConfiguration
     {
         public string ClientName { get; set; }
-        public bool UseInMemoryStores { get; set; }
         public string StorageProvider { get; set; }
         public ElasticSearchSettings ElasticSearchSettings { get; set; }
         public IdentityServerConfidentialClientSettings IdentityServerConfidentialClientSettings { get; set; }

--- a/Fabric.Authorization.API/Configuration/AppConfiguration.cs
+++ b/Fabric.Authorization.API/Configuration/AppConfiguration.cs
@@ -6,6 +6,7 @@ namespace Fabric.Authorization.API.Configuration
     {
         public string ClientName { get; set; }
         public bool UseInMemoryStores { get; set; }
+        public string StorageProvider { get; set; }
         public ElasticSearchSettings ElasticSearchSettings { get; set; }
         public IdentityServerConfidentialClientSettings IdentityServerConfidentialClientSettings { get; set; }
         public CouchDbSettings CouchDbSettings { get; set; }

--- a/Fabric.Authorization.API/Configuration/IAppConfiguration.cs
+++ b/Fabric.Authorization.API/Configuration/IAppConfiguration.cs
@@ -5,7 +5,6 @@ namespace Fabric.Authorization.API.Configuration
     public interface IAppConfiguration
     {
         string ClientName { get; }
-        bool UseInMemoryStores { get; }
         string StorageProvider { get; }
         ElasticSearchSettings ElasticSearchSettings { get; }
         IdentityServerConfidentialClientSettings IdentityServerConfidentialClientSettings { get; }

--- a/Fabric.Authorization.API/Configuration/IAppConfiguration.cs
+++ b/Fabric.Authorization.API/Configuration/IAppConfiguration.cs
@@ -6,6 +6,7 @@ namespace Fabric.Authorization.API.Configuration
     {
         string ClientName { get; }
         bool UseInMemoryStores { get; }
+        string StorageProvider { get; }
         ElasticSearchSettings ElasticSearchSettings { get; }
         IdentityServerConfidentialClientSettings IdentityServerConfidentialClientSettings { get; }
         CouchDbSettings CouchDbSettings { get; }

--- a/Fabric.Authorization.API/Constants/StorageProviders.cs
+++ b/Fabric.Authorization.API/Constants/StorageProviders.cs
@@ -3,7 +3,7 @@
     public static class StorageProviders
     {
         public const string InMemory = "inmemory";
-        public const string CouchDb = "coucdb";
+        public const string CouchDb = "couchdb";
         public const string SqlServer = "sqlserver";
     }
 }

--- a/Fabric.Authorization.API/Constants/StorageProviders.cs
+++ b/Fabric.Authorization.API/Constants/StorageProviders.cs
@@ -1,0 +1,9 @@
+﻿namespace Fabric.Authorization.API.Constants
+{
+    public static class StorageProviders
+    {
+        public const string InMemory = "inmemory";
+        public const string CouchDb = "coucdb";
+        public const string SqlServer = "sqlserver";
+    }
+}

--- a/Fabric.Authorization.API/Startup.cs
+++ b/Fabric.Authorization.API/Startup.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Fabric.Authorization.API.Configuration;
 using Fabric.Authorization.API.Constants;
@@ -68,7 +69,7 @@ namespace Fabric.Authorization.API
         public async Task<bool> HealthCheck()
         {
             var eventContextResolverService = new EventContextResolverService(new NancyContextWrapper(new NancyContext()));
-            var clientStore = _appConfig.StorageProvider == StorageProviders.InMemory
+            var clientStore = _appConfig.StorageProvider.Equals(StorageProviders.InMemory, StringComparison.OrdinalIgnoreCase)
                 ? (IClientStore) new InMemoryClientStore()
                 : new CouchDbClientStore(new CouchDbAccessService(_appConfig.CouchDbSettings, _logger), _logger, eventContextResolverService);
             

--- a/Fabric.Authorization.API/Startup.cs
+++ b/Fabric.Authorization.API/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Fabric.Authorization.API.Configuration;
+using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Infrastructure;
 using Fabric.Authorization.API.Services;
 using Fabric.Authorization.Domain.Stores;
@@ -67,7 +68,7 @@ namespace Fabric.Authorization.API
         public async Task<bool> HealthCheck()
         {
             var eventContextResolverService = new EventContextResolverService(new NancyContextWrapper(new NancyContext()));
-            var clientStore = _appConfig.UseInMemoryStores
+            var clientStore = _appConfig.StorageProvider == StorageProviders.InMemory
                 ? (IClientStore) new InMemoryClientStore()
                 : new CouchDbClientStore(new CouchDbAccessService(_appConfig.CouchDbSettings, _logger), _logger, eventContextResolverService);
             

--- a/Fabric.Authorization.API/appsettings.json
+++ b/Fabric.Authorization.API/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ClientName": "hc",
-  "UseInMemoryStores": false,
+  "StorageProvider": "couchdb",
   "ElasticSearchSettings": {
     "Scheme": "http",
     "Server": "localhost",

--- a/Fabric.Authorization.Domain/Stores/AuditingDocumentDbService.cs
+++ b/Fabric.Authorization.Domain/Stores/AuditingDocumentDbService.cs
@@ -68,5 +68,15 @@ namespace Fabric.Authorization.Domain.Stores
         {
             return await _innerDocumentDbService.GetDocuments<T>(designdoc, viewName, customParams);
         }
+
+        public async Task Initialize()
+        {
+            await  _innerDocumentDbService.Initialize();
+        }
+
+        public async Task SetupDefaultUser()
+        {
+            await _innerDocumentDbService.SetupDefaultUser();
+        }
     }
 }

--- a/Fabric.Authorization.Domain/Stores/CachingDocumentDbService.cs
+++ b/Fabric.Authorization.Domain/Stores/CachingDocumentDbService.cs
@@ -84,5 +84,15 @@ namespace Fabric.Authorization.Domain.Stores
         {
             return await _innerDocumentDbService.GetDocuments<T>(designdoc, viewName, customParams);
         }
+
+        public async Task Initialize()
+        {
+            await _innerDocumentDbService.Initialize();
+        }
+
+        public async Task SetupDefaultUser()
+        {
+            await _innerDocumentDbService.SetupDefaultUser();
+        }
     }
 }

--- a/Fabric.Authorization.Domain/Stores/CouchDB/CouchDbBootstrapper.cs
+++ b/Fabric.Authorization.Domain/Stores/CouchDB/CouchDbBootstrapper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Serilog;
+
+namespace Fabric.Authorization.Domain.Stores.CouchDB
+{
+    public class CouchDbBootstrapper : IDbBootstrapper
+    {
+        private readonly IDocumentDbService _documentDbService;
+        private readonly ILogger _logger;
+        public CouchDbBootstrapper(IDocumentDbService documentDbService, ILogger logger)
+        {
+            _documentDbService = documentDbService ?? throw new ArgumentNullException(nameof(documentDbService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+        public void Setup()
+        {
+            _documentDbService.Initialize().Wait();
+            _documentDbService.SetupDefaultUser().Wait();
+            _documentDbService.AddViews("roles", CouchDbRoleStore.GetViews()).Wait();
+            _documentDbService.AddViews("permissions", CouchDbPermissionStore.GetViews()).Wait();
+        }
+    }
+}

--- a/Fabric.Authorization.Domain/Stores/IDbBootstrapper.cs
+++ b/Fabric.Authorization.Domain/Stores/IDbBootstrapper.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fabric.Authorization.Domain.Stores
+{
+    public interface IDbBootstrapper
+    {
+        void Setup();
+    }
+}

--- a/Fabric.Authorization.Domain/Stores/IDocumentDbService.cs
+++ b/Fabric.Authorization.Domain/Stores/IDocumentDbService.cs
@@ -23,5 +23,9 @@ namespace Fabric.Authorization.Domain.Stores
         Task<IEnumerable<T>> GetDocuments<T>(string designdoc, string viewName, Dictionary<string, object> customParams);
 
         Task<IEnumerable<T>> GetDocuments<T>(string designdoc, string viewName, string customParams);
+
+        Task Initialize();
+
+        Task SetupDefaultUser();
     }
 }

--- a/Fabric.Authorization.Domain/Stores/InMemory/InMemoryDbBootstrapper.cs
+++ b/Fabric.Authorization.Domain/Stores/InMemory/InMemoryDbBootstrapper.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Fabric.Authorization.Domain.Stores.InMemory
+{
+    public class InMemoryDbBootstrapper : IDbBootstrapper
+    {
+        public void Setup()
+        {
+            return;
+        }
+    }
+}

--- a/Fabric.Authorization.IntegrationTests/CouchDB/CouchClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/CouchDB/CouchClientTests.cs
@@ -1,4 +1,5 @@
-﻿using Fabric.Authorization.IntegrationTests.Modules;
+﻿using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.IntegrationTests.Modules;
 using Xunit;
 
 namespace Fabric.Authorization.IntegrationTests.CouchDB
@@ -6,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.CouchDB
     [Collection("CouchTests")]
     public class CouchClientTests : ClientTests
     {
-        public CouchClientTests(IntegrationTestsFixture fixture) : base(fixture, useInMemoryDb: false)
+        public CouchClientTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.CouchDb)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBGroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBGroupsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.Domain.Models;
 using Fabric.Authorization.Domain.Stores;
 using Fabric.Authorization.IntegrationTests.Modules;
@@ -13,10 +14,10 @@ namespace Fabric.Authorization.IntegrationTests.CouchDB
     {
         private readonly IDocumentDbService _documentDbService;
         private readonly Browser _browser;
-        public CouchDbGroupsTests(IntegrationTestsFixture fixture) : base(fixture, false)
+        public CouchDbGroupsTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.CouchDb)
         {
             _documentDbService = fixture.DbService();
-            _browser = fixture.GetBrowser(Principal, false);
+            _browser = fixture.GetBrowser(Principal, StorageProviders.CouchDb);
         }
 
         

--- a/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBPermissionsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBPermissionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Fabric.Authorization.IntegrationTests.Modules;
+﻿using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.IntegrationTests.Modules;
 using Xunit;
 
 namespace Fabric.Authorization.IntegrationTests.CouchDB
@@ -6,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.CouchDB
     [Collection("CouchTests")]
     public class CouchDBPermissionsTests : PermissionsTests
     {
-        public CouchDBPermissionsTests(IntegrationTestsFixture fixture) : base(fixture, useInMemoryDb: false)
+        public CouchDBPermissionsTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.CouchDb)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBRolesTests.cs
+++ b/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBRolesTests.cs
@@ -1,4 +1,5 @@
-﻿using Fabric.Authorization.IntegrationTests.Modules;
+﻿using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.IntegrationTests.Modules;
 using Xunit;
 
 namespace Fabric.Authorization.IntegrationTests.CouchDB
@@ -6,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.CouchDB
     [Collection("CouchTests")]
     public class CouchDBRolesTests : RolesTests, IClassFixture<IntegrationTestsFixture>
     {
-        public CouchDBRolesTests(IntegrationTestsFixture fixture) : base(fixture, useInMemoryDb: false)
+        public CouchDBRolesTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.CouchDb)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBUserTests.cs
+++ b/Fabric.Authorization.IntegrationTests/CouchDB/CouchDBUserTests.cs
@@ -1,4 +1,5 @@
-﻿using Fabric.Authorization.IntegrationTests.Modules;
+﻿using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.IntegrationTests.Modules;
 using Xunit;
 
 namespace Fabric.Authorization.IntegrationTests.CouchDB
@@ -6,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.CouchDB
     [Collection("CouchTests")]
     public class CouchDBUserTests : UserTests, IClassFixture<IntegrationTestsFixture>
     {
-        public CouchDBUserTests(IntegrationTestsFixture fixture) : base(fixture, false)
+        public CouchDBUserTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.CouchDb)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/CouchDB/CouchDbIdentitySearchTests.cs
+++ b/Fabric.Authorization.IntegrationTests/CouchDB/CouchDbIdentitySearchTests.cs
@@ -1,4 +1,5 @@
-﻿using Fabric.Authorization.IntegrationTests.Modules;
+﻿using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.IntegrationTests.Modules;
 using Xunit;
 
 namespace Fabric.Authorization.IntegrationTests.CouchDB
@@ -8,7 +9,7 @@ namespace Fabric.Authorization.IntegrationTests.CouchDB
     {
         public CouchDbIdentitySearchTests(IdentitySearchFixture fixture) : base(fixture)
         {
-            Fixture.Initialize(false);
+            Fixture.Initialize(StorageProviders.CouchDb);
         }
     }
 }

--- a/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
+++ b/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
@@ -28,12 +28,12 @@ namespace Fabric.Authorization.IntegrationTests
         }
         public Browser Browser { get; set; }
 
-        public Browser GetBrowser(ClaimsPrincipal principal, bool useInMemoryStores, IIdentityServiceProvider identityServiceProvider = null)
+        public Browser GetBrowser(ClaimsPrincipal principal, string storageProvider, IIdentityServiceProvider identityServiceProvider = null)
         {
             var appConfiguration = new AppConfiguration
             {
                 CouchDbSettings = CouchDbSettings,
-                UseInMemoryStores = useInMemoryStores,
+                StorageProvider = storageProvider,
                 IdentityServerConfidentialClientSettings = new IdentityServerConfidentialClientSettings
                 {
                     Authority = "http://localhost",

--- a/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
+++ b/Fabric.Authorization.IntegrationTests/IntegrationTestsFixture.cs
@@ -103,8 +103,8 @@ namespace Fabric.Authorization.IntegrationTests
             CouchDbSettings config = new CouchDbSettings()
             {
                 DatabaseName = "integration-" + DateTime.UtcNow.Ticks,
-                Username = "admin",
-                Password = "admin",
+                Username = "",
+                Password = "",
                 Server = "http://127.0.0.1:5984"
             };
 

--- a/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
@@ -13,7 +13,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
     public class ClientTests : IClassFixture<IntegrationTestsFixture>
     {
         private readonly Browser _browser;
-        public ClientTests(IntegrationTestsFixture fixture, bool useInMemoryDb = true)
+        public ClientTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
         {
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
             {
@@ -22,7 +22,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 new Claim(Claims.Scope, Scopes.WriteScope),
             }, "testprincipal"));
 
-            _browser = fixture.GetBrowser(principal, useInMemoryDb);
+            _browser = fixture.GetBrowser(principal, storageProvider);
         }
 
         [Theory]

--- a/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
@@ -26,9 +26,9 @@ namespace Fabric.Authorization.IntegrationTests.Modules
             new Claim(Claims.IdentityProvider, "idP1")
         }, "rolesprincipal"));
 
-        public GroupsTests(IntegrationTestsFixture fixture, bool useInMemoryDb = true)
+        public GroupsTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
         {
-            _browser = fixture.GetBrowser(Principal, useInMemoryDb);
+            _browser = fixture.GetBrowser(Principal, storageProvider);
             _defaultPropertySettings = fixture.DefaultPropertySettings;
 
             _browser.Post("/clients", with =>

--- a/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
@@ -5,7 +5,6 @@ using System.Security.Claims;
 using Fabric.Authorization.API.Configuration;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Models;
-using Fabric.Authorization.Domain.Stores;
 using Nancy;
 using Nancy.Testing;
 using Xunit;

--- a/Fabric.Authorization.IntegrationTests/Modules/IdentitySearchTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/IdentitySearchTests.cs
@@ -22,7 +22,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         public IdentitySearchTests(IdentitySearchFixture fixture)
         {
             Fixture = fixture;
-            Fixture.Initialize(true);
+            Fixture.Initialize(StorageProviders.InMemory);
         }
 
         [Fact]
@@ -182,11 +182,11 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         public string AdminAtlasRoleName { get; private set; }
         public string UserAtlasRoleName { get; private set; }
         
-        private bool _useInMemoryDb;
+        private string _storageProvider;
 
-        public void Initialize(bool useInMemoryDb)
+        public void Initialize(string storageProvider)
         {
-            _useInMemoryDb = useInMemoryDb;
+            _storageProvider = storageProvider;
             AtlasClientId = $"atlas-{DateTime.Now.Ticks}";
             AdminAtlasGroupName = $"adminAtlasGroup-{DateTime.Now.Ticks}";
             UserAtlasGroupName = $"userAtlasGroup-{DateTime.Now.Ticks}";
@@ -204,7 +204,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 new Claim(Claims.ClientId, AtlasClientId),
                 new Claim(Claims.IdentityProvider, "idP1")
             }, "rolesprincipal"));
-            Browser = GetBrowser(principal, _useInMemoryDb, identityServiceProvider);
+            Browser = GetBrowser(principal, _storageProvider, identityServiceProvider);
         }
 
         public void InitializeSuccessData(IIdentityServiceProvider identityServiceProvider)

--- a/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
@@ -14,7 +14,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         private readonly Browser _browser;
         private readonly string _securableItem;
 
-        public PermissionsTests(IntegrationTestsFixture fixture, bool useInMemoryDb = true)
+        public PermissionsTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
         {
             _securableItem = "permissionprincipal" + Guid.NewGuid();
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
@@ -25,7 +25,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 new Claim(Claims.ClientId, _securableItem)
             }, _securableItem));
 
-            _browser = fixture.GetBrowser(principal, useInMemoryDb);
+            _browser = fixture.GetBrowser(principal, storageProvider);
             fixture.CreateClient(_browser, _securableItem);
         }
 

--- a/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
@@ -19,7 +19,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         private readonly Browser _browser;
         private readonly string _securableItem;
         private readonly string _subjectId;
-        public RolesTests(IntegrationTestsFixture fixture, bool useInMemoryDb = true)
+        public RolesTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
         {
             _securableItem = "rolesprincipal" + Guid.NewGuid();
             _subjectId = _securableItem;
@@ -31,7 +31,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 new Claim(Claims.ClientId, _securableItem)
             }, _securableItem));
 
-            _browser = fixture.GetBrowser(principal, useInMemoryDb);
+            _browser = fixture.GetBrowser(principal, storageProvider);
             fixture.CreateClient(_browser, _securableItem);
         }
 

--- a/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
@@ -26,7 +26,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
 
         private readonly Browser _browser;
         private readonly string _securableItem;
-        public UserTests(IntegrationTestsFixture fixture, bool useInMemoryDB = true)
+        public UserTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
         {
 
             _securableItem = "userprincipal" + Guid.NewGuid();
@@ -42,7 +42,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                     new Claim(JwtClaimTypes.Role, Group2),
                     new Claim(JwtClaimTypes.IdentityProvider, IdentityProvider)
                 }, _securableItem));
-            _browser = fixture.GetBrowser(principal, useInMemoryDB);
+            _browser = fixture.GetBrowser(principal, storageProvider);
             fixture.CreateClient(_browser, _securableItem);
         }
 

--- a/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Fabric.Authorization.Domain.Stores;
+
+namespace Fabric.Authorization.Persistence.SqlServer.Services
+{
+    public class SqlServerDbBootstrapper : IDbBootstrapper
+    {
+        public void Setup()
+        {
+            return;
+        }
+    }
+}


### PR DESCRIPTION
Sorry for the size of the PR, most of the changes are small, but I did do a little refactoring in the bootstrapper to simplify it a bit. I also extracted an IDbBootstrapper interface like we have in Identity.