### PR TITLE
get client tests passing for sql server

### DIFF
--- a/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
@@ -141,14 +141,16 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 }
             };
 
-            _browser.Post("/clients", with =>
+            var postResponse = _browser.Post("/clients", with =>
             {
                 with.HttpRequest();
                 with.JsonBody(clientToAdd);
-            }).Wait();
+            }).Result;
+
+            Assert.Equal(HttpStatusCode.Created, postResponse.StatusCode);
 
             // Repeat
-            var postResponse = _browser.Post("/clients", with =>
+            postResponse = _browser.Post("/clients", with =>
             {
                 with.HttpRequest();
                 with.JsonBody(clientToAdd);

--- a/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
@@ -99,7 +99,15 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         [InlineData("6BC32347-36A1-44CF-AA0E-6C1038AA1DF3")]
         public void TestAddNewClient_Success(string id)
         {
-            var clientToAdd = new ClientApiModel { Id = id, Name = id };
+            var clientToAdd = new ClientApiModel
+            {
+                Id = id,
+                Name = id,
+                TopLevelSecurableItem = new SecurableItemApiModel
+                {
+                    Name = id
+                }
+            };
 
             var postResponse = _browser.Post("/clients", with =>
             {
@@ -123,7 +131,15 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         [InlineData("D622053D-03F5-489E-84F7-5471DA309213")]
         public void TestAddNewClient_Fail(string id)
         {
-            var clientToAdd = new ClientApiModel { Id = id, Name = id };
+            var clientToAdd = new ClientApiModel
+            {
+                Id = id,
+                Name = id,
+                TopLevelSecurableItem = new SecurableItemApiModel
+                {
+                    Name = id
+                }
+            };
 
             _browser.Post("/clients", with =>
             {
@@ -150,7 +166,15 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         [InlineData("F8C01F6B-C09C-430C-97A5-A0F2F1B340FB")]
         public void TestDeleteClient_Success(string id)
         {
-            var clientToAdd = new ClientApiModel { Id = id, Name = id };
+            var clientToAdd = new ClientApiModel
+            {
+                Id = id,
+                Name = id,
+                TopLevelSecurableItem = new SecurableItemApiModel
+                {
+                    Name = id
+                }
+            };
 
             _browser.Post("/clients", with =>
             {

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerClientTests.cs
@@ -5,9 +5,9 @@ using Xunit;
 namespace Fabric.Authorization.IntegrationTests.SqlServer
 {
     [Collection("SqlServerTests")]
-    public class SqlServerClientTests //: ClientTests
+    public class SqlServerClientTests : ClientTests
     {
-        public SqlServerClientTests(IntegrationTestsFixture fixture)// : base(fixture,StorageProviders.SqlServer)
+        public SqlServerClientTests(IntegrationTestsFixture fixture) : base(fixture,StorageProviders.SqlServer)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerClientTests.cs
@@ -5,9 +5,9 @@ using Xunit;
 namespace Fabric.Authorization.IntegrationTests.SqlServer
 {
     [Collection("SqlServerTests")]
-    public class SqlServerClientTests : ClientTests
+    public class SqlServerClientTests //: ClientTests
     {
-        public SqlServerClientTests(IntegrationTestsFixture fixture) : base(fixture,StorageProviders.SqlServer)
+        public SqlServerClientTests(IntegrationTestsFixture fixture) //: base(fixture,StorageProviders.SqlServer)
         {
         }
     }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapper.cs
@@ -1,5 +1,6 @@
 ﻿using AutoMapper;
 
+
 namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 {
     public static class ClientMapper
@@ -19,7 +20,21 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 
         public static EntityModels.Client ToEntity(this Domain.Models.Client model)
         {
-            return model == null ? null : Mapper.Map<EntityModels.Client>(model);
+            if (model == null)
+            {
+                return null;
+            }
+
+            var entity = Mapper.Map<EntityModels.Client>(model);
+
+            entity.TopLevelSecurableItem = new EntityModels.SecurableItem
+            {
+                Name = model.TopLevelSecurableItem.Name
+            };
+
+            
+
+            return entity;
         }
 
         public static void ToEntity(this Domain.Models.Client model, EntityModels.Client entity)

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapper.cs
@@ -4,15 +4,7 @@
 namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 {
     public static class ClientMapper
-    {
-        internal static IMapper Mapper { get; }
-
-        static ClientMapper()
-        {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<ClientMapperProfile>())
-                .CreateMapper();
-        }
-
+    { 
         public static Domain.Models.Client ToModel(this EntityModels.Client entity)
         {
             return entity == null ? null : Mapper.Map<Domain.Models.Client>(entity);
@@ -20,21 +12,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 
         public static EntityModels.Client ToEntity(this Domain.Models.Client model)
         {
-            if (model == null)
-            {
-                return null;
-            }
-
-            var entity = Mapper.Map<EntityModels.Client>(model);
-
-            entity.TopLevelSecurableItem = new EntityModels.SecurableItem
-            {
-                Name = model.TopLevelSecurableItem.Name
-            };
-
-            
-
-            return entity;
+            return model == null ? null : Mapper.Map<EntityModels.Client>(model);
         }
 
         public static void ToEntity(this Domain.Models.Client model, EntityModels.Client entity)

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapperProfile.cs
@@ -9,7 +9,8 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
             //entity to model 
             CreateMap<EntityModels.Client, Domain.Models.Client>()
                 .ForMember(x => x.Id, opt => opt.MapFrom(src => src.ClientId))
-                .ReverseMap();           
+                .ReverseMap()
+                .ForPath(x => x.ClientId, opt => opt.MapFrom(x => x.Id));
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapperProfile.cs
@@ -9,8 +9,11 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
             //entity to model 
             CreateMap<EntityModels.Client, Domain.Models.Client>()
                 .ForMember(x => x.Id, opt => opt.MapFrom(src => src.ClientId))
+                .ForMember(x => x.TopLevelSecurableItem, opt => opt.Ignore())
                 .ReverseMap()
-                .ForPath(x => x.ClientId, opt => opt.MapFrom(x => x.Id));
+                .ForPath(x => x.ClientId, opt => opt.MapFrom(x => x.Id))
+                .ForMember(x => x.Id, opt => opt.Ignore())
+                .ForMember(x => x.TopLevelSecurableItem, opt => opt.Ignore());
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/ClientMapperProfile.cs
@@ -9,11 +9,13 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
             //entity to model 
             CreateMap<EntityModels.Client, Domain.Models.Client>()
                 .ForMember(x => x.Id, opt => opt.MapFrom(src => src.ClientId))
-                .ForMember(x => x.TopLevelSecurableItem, opt => opt.Ignore())
+
                 .ReverseMap()
                 .ForPath(x => x.ClientId, opt => opt.MapFrom(x => x.Id))
+                .ForMember(x => x.TopLevelSecurableItem, opt => opt.MapFrom(src => src.TopLevelSecurableItem))
                 .ForMember(x => x.Id, opt => opt.Ignore())
-                .ForMember(x => x.TopLevelSecurableItem, opt => opt.Ignore());
+                .ForMember(x => x.SecurableItemId, opt => opt.Ignore());
+         
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/GroupMapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/GroupMapper.cs
@@ -4,14 +4,6 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 {
     public static class GroupMapper
     {
-        internal static IMapper Mapper { get; }
-
-        static GroupMapper()
-        {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<GroupMapperProfile>())
-                .CreateMapper();
-        }
-
         public static Domain.Models.Group ToModel(this EntityModels.Group entity)
         {
             return entity == null ? null : Mapper.Map<Domain.Models.Group>(entity);

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/PermissionMapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/PermissionMapper.cs
@@ -4,14 +4,6 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 {
     public static class PermissionMapper
     {
-        internal static IMapper Mapper { get; }
-
-        static PermissionMapper()
-        {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<PermissionMapperProfile>())
-                .CreateMapper();
-        }
-
         public static Domain.Models.Permission ToModel(this EntityModels.Permission entity)
         {
             return entity == null ? null : Mapper.Map<Domain.Models.Permission>(entity);

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/RoleMapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/RoleMapper.cs
@@ -4,14 +4,6 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 {
     public static class RoleMapper
     {
-        internal static IMapper Mapper { get; }
-
-        static RoleMapper()
-        {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<RoleMapperProfile>())
-                .CreateMapper();
-        }
-
         public static Domain.Models.Role ToModel(this EntityModels.Role entity)
         {
             return entity == null ? null : Mapper.Map<Domain.Models.Role>(entity);

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapper.cs
@@ -4,14 +4,6 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 {
     public static class SecurableItemMapper
     {
-        internal static IMapper Mapper { get; }
-
-        static SecurableItemMapper()
-        {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<SecurableItemMapperProfile>())
-                .CreateMapper();
-        }
-
         public static Domain.Models.SecurableItem ToModel(this EntityModels.SecurableItem entity)
         {
             return entity == null ? null : Mapper.Map<Domain.Models.SecurableItem>(entity);

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapperProfile.cs
@@ -8,10 +8,17 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
         {
             CreateMap<EntityModels.SecurableItem, Domain.Models.SecurableItem>()
                 .ForMember(x => x.Id, opt => opt.MapFrom(src => src.SecurableItemId))
+                .ForMember(x => x.SecurableItems, opt => opt.MapFrom(src => src.SecurableItems))
                 .ReverseMap()
-                .ForMember(x => x.SecurableItemId, opt => opt.MapFrom(src => src.Id))
+                .ForPath(x => x.SecurableItemId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(x => x.SecurableItems, opt => opt.MapFrom(src => src.SecurableItems))
                 .ForMember(x => x.Id, opt => opt.Ignore())
-                .ForMember(x => x.Parent, src => src.Ignore());
+                .ForPath(x => x.Id, opt => opt.Ignore())
+                .ForPath(x => x.Parent, opt => opt.Ignore())
+                .ForPath(x => x.ParentId, opt => opt.Ignore())
+                .ForPath(x => x.Client, opt => opt.Ignore())
+                .ForPath(x => x.Permissions, opt => opt.Ignore())
+                .ForPath(x => x.Roles, opt => opt.Ignore());
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapperProfile.cs
@@ -8,7 +8,10 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
         {
             CreateMap<EntityModels.SecurableItem, Domain.Models.SecurableItem>()
                 .ForMember(x => x.Id, opt => opt.MapFrom(src => src.SecurableItemId))
-                .ReverseMap();
+                .ReverseMap()
+                .ForMember(x => x.SecurableItemId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(x => x.Id, opt => opt.Ignore())
+                .ForMember(x => x.Parent, src => src.Ignore());
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/UserMapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/UserMapper.cs
@@ -4,14 +4,6 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
 {
     public static class UserMapper
     {
-        internal static IMapper Mapper { get; }
-
-        static UserMapper()
-        {
-            Mapper = new MapperConfiguration(cfg => cfg.AddProfile<UserMapperProfile>())
-                .CreateMapper();
-        }
-
         public static Domain.Models.User ToModel(this EntityModels.User entity)
         {
             return entity == null ? null : Mapper.Map<Domain.Models.User>(entity);

--- a/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
@@ -1,4 +1,6 @@
-﻿using Fabric.Authorization.Domain.Services;
+﻿using AutoMapper;
+using Fabric.Authorization.Domain.Services;
+using Fabric.Authorization.Persistence.SqlServer.Mappers;
 
 namespace Fabric.Authorization.Persistence.SqlServer.Services
 {
@@ -6,6 +8,8 @@ namespace Fabric.Authorization.Persistence.SqlServer.Services
     {
         public void Setup()
         {
+            //register all the automapper profiles
+            Mapper.Initialize(cfg => cfg.AddProfiles(typeof(ClientMapperProfile)));
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
@@ -6,10 +6,15 @@ namespace Fabric.Authorization.Persistence.SqlServer.Services
 {
     public class SqlServerDbBootstrapper : IDbBootstrapper
     {
+        static SqlServerDbBootstrapper()
+        {
+            //register all the automapper profiles - only ever want to call this once
+            Mapper.Initialize(cfg => cfg.AddProfiles(typeof(ClientMapperProfile)));
+        }
+
         public void Setup()
         {
-            //register all the automapper profiles
-            Mapper.Initialize(cfg => cfg.AddProfiles(typeof(ClientMapperProfile)));
+            
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerClientStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerClientStore.cs
@@ -81,7 +81,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
             topLevelSecurableItem.IsDeleted = true;
             foreach (var securableItem in topLevelSecurableItem.SecurableItems)
             {
-                MarkSecurableItemsDeleted(securableItem);                               
+                MarkSecurableItemsDeleted(securableItem);
             }
         }
 


### PR DESCRIPTION
changed the way automapper profiles are initialized, they are all initialized by the sql server bootstrapper

fixed up the securable item mapping