### PR TITLE
fixes to get roles handled properly by EF and automapper

### DIFF
--- a/Fabric.Authorization.Persistence.SqlServer/Extensions/ModelBuilderExtensions.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Extensions/ModelBuilderExtensions.cs
@@ -138,7 +138,11 @@ namespace Fabric.Authorization.Persistence.SqlServer.Extensions
             {
                 entity.ToTable("Roles");
 
-                entity.Property(e => e.Id)
+                entity.HasKey(e => e.RoleId)
+                    .ForSqlServerIsClustered(false);
+
+                entity.Property(e => e.Id)  
+                    .ValueGeneratedOnAdd()
                     .UseSqlServerIdentityColumn();
 
                 entity.Property(e => e.SecurableItemId)
@@ -168,11 +172,10 @@ namespace Fabric.Authorization.Persistence.SqlServer.Extensions
                 entity.Property(e => e.ModifiedDateTimeUtc)
                     .HasColumnType("datetime");
 
-                entity.HasKey(e => e.RoleId)
-                    .ForSqlServerIsClustered(false);
                 entity.HasIndex(e => e.Id)
                     .IsUnique()
                     .ForSqlServerIsClustered();
+
                 entity.HasIndex(e => e.SecurableItemId)
                     .HasName("IX_Roles_SecurableItemId");
 

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/RoleMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/RoleMapperProfile.cs
@@ -9,15 +9,17 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
         {
             CreateMap<EntityModels.Role, Domain.Models.Role>()
                 .ForMember(x => x.Id, opt => opt.MapFrom(src => src.RoleId))
+                .ForMember(x => x.SecurableItem, opt => opt.MapFrom(src => src.SecurableItem.Name))
                 .ForMember(x => x.ParentRole, opt => opt.MapFrom(src => src.ParentRole.RoleId))
                 .ForMember(x => x.Groups, opt => opt.MapFrom(src => src.Groups.Select(g => g.Name)))
                 .ForMember(x => x.ChildRoles, opt => opt.MapFrom(src => src.ChildRoles.Select(cr => cr.RoleId)))
                 .ForMember(x => x.Permissions, opt => opt.MapFrom(src => src.AllowedPermissions))
                 .ForMember(x => x.DeniedPermissions, opt => opt.MapFrom(src => src.DeniedPermissions))
-                .ReverseMap();
+                .ReverseMap()
+                .ForMember(x => x.RoleId, opt => opt.MapFrom(src => src.Id))
+                .ForPath(x => x.SecurableItem.Name, opt => opt.MapFrom(src => src.SecurableItem))
+                .ForMember(x => x.ParentRole, opt => opt.Ignore());
 
-            CreateMap<EntityModels.Role, Domain.Models.Role>()
-                .ForMember(x => x.SecurableItem, opt => opt.MapFrom(src => src.SecurableItem.Name));
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/SecurableItemMapperProfile.cs
@@ -10,15 +10,15 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
                 .ForMember(x => x.Id, opt => opt.MapFrom(src => src.SecurableItemId))
                 .ForMember(x => x.SecurableItems, opt => opt.MapFrom(src => src.SecurableItems))
                 .ReverseMap()
-                .ForPath(x => x.SecurableItemId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(x => x.SecurableItemId, opt => opt.MapFrom(src => src.Id))
                 .ForMember(x => x.SecurableItems, opt => opt.MapFrom(src => src.SecurableItems))
                 .ForMember(x => x.Id, opt => opt.Ignore())
-                .ForPath(x => x.Id, opt => opt.Ignore())
-                .ForPath(x => x.Parent, opt => opt.Ignore())
-                .ForPath(x => x.ParentId, opt => opt.Ignore())
-                .ForPath(x => x.Client, opt => opt.Ignore())
-                .ForPath(x => x.Permissions, opt => opt.Ignore())
-                .ForPath(x => x.Roles, opt => opt.Ignore());
+                .ForMember(x => x.Id, opt => opt.Ignore())
+                .ForMember(x => x.Parent, opt => opt.Ignore())
+                .ForMember(x => x.ParentId, opt => opt.Ignore())
+                .ForMember(x => x.Client, opt => opt.Ignore())
+                .ForMember(x => x.Permissions, opt => opt.Ignore())
+                .ForMember(x => x.Roles, opt => opt.Ignore());
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Services/SqlServerDbBootstrapper.cs
@@ -9,7 +9,9 @@ namespace Fabric.Authorization.Persistence.SqlServer.Services
         static SqlServerDbBootstrapper()
         {
             //register all the automapper profiles - only ever want to call this once
-            Mapper.Initialize(cfg => cfg.AddProfiles(typeof(ClientMapperProfile)));
+            //http://automapper.readthedocs.io/en/latest/Configuration.html#assembly-scanning-for-auto-configuration
+            Mapper.Initialize(cfg => cfg.AddProfiles(typeof(SqlServerDbBootstrapper)));
+           // Mapper.AssertConfigurationIsValid();            
         }
 
         public void Setup()


### PR DESCRIPTION
also updated the SqlDbBootstrapper code that initializes the automapper profiles to use the SqlDbBootstrapper as the type in the assembly to scan to reduce confusion. 

