### PR TITLE
Only create one database per test run. Clean up database after test run.

### DIFF
--- a/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/ClientTests.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Models;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Nancy;
 using Nancy.Testing;
 using Newtonsoft.Json;
@@ -18,8 +19,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         private readonly Browser _browser;
         private readonly IntegrationTestsFixture _fixture;
         private readonly string _storageProvider;
-        public ClientTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
+        public ClientTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory, ConnectionStrings connectionStrings = null)
         {
+            if (connectionStrings != null)
+            {
+                fixture.ConnectionStrings = connectionStrings;
+            }
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
             {
                 new Claim(Claims.Scope, Scopes.ManageClientsScope),

--- a/Fabric.Authorization.IntegrationTests/Modules/DosTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/DosTests.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Models;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Nancy;
 using Nancy.Testing;
 using Newtonsoft.Json;
@@ -16,8 +17,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
     {
         private readonly IntegrationTestsFixture _fixture;
         private readonly string _storageProvider;
-        public DosTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
+        public DosTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory, ConnectionStrings connectionStrings = null)
         {
+            if (connectionStrings != null)
+            {
+                fixture.ConnectionStrings = connectionStrings;
+            }
             _fixture = fixture;
             _storageProvider = storageProvider;
         }

--- a/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Fabric.Authorization.API.Configuration;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Models;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Nancy;
 using Nancy.Testing;
 using Xunit;
@@ -26,8 +27,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
             new Claim(Claims.IdentityProvider, "idP1")
         }, "rolesprincipal"));
 
-        public GroupsTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
+        public GroupsTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory, ConnectionStrings connectionStrings = null)
         {
+            if (connectionStrings != null)
+            {
+                fixture.ConnectionStrings = connectionStrings;
+            }
             Browser = fixture.GetBrowser(Principal, storageProvider);
             _defaultPropertySettings = fixture.DefaultPropertySettings;
             fixture.CreateClient(Browser, "rolesprincipal");

--- a/Fabric.Authorization.IntegrationTests/Modules/IdentitySearchTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/IdentitySearchTests.cs
@@ -8,6 +8,7 @@ using Fabric.Authorization.API.Models;
 using Fabric.Authorization.API.Models.Search;
 using Fabric.Authorization.API.RemoteServices.Identity.Models;
 using Fabric.Authorization.API.RemoteServices.Identity.Providers;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Moq;
 using Nancy;
 using Nancy.Testing;
@@ -20,8 +21,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
     {
         protected readonly IdentitySearchFixture Fixture;
 
-        public IdentitySearchTests(IdentitySearchFixture fixture)
+        public IdentitySearchTests(IdentitySearchFixture fixture, ConnectionStrings connectionStrings = null)
         {
+            if (connectionStrings != null)
+            {
+                fixture.ConnectionStrings = connectionStrings;
+            }
             Fixture = fixture;
             Fixture.Initialize(StorageProviders.InMemory);
         }

--- a/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/PermissionsTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Nancy;
 using Nancy.Testing;
 using Xunit;
@@ -15,8 +16,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         private readonly Browser _browser;
         private readonly string _securableItem;
 
-        public PermissionsTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
+        public PermissionsTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory, ConnectionStrings connectionStrings = null)
         {
+            if (connectionStrings != null)
+            {
+                fixture.ConnectionStrings = connectionStrings;
+            }
             _securableItem = "permissionprincipal" + Guid.NewGuid();
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
             {

--- a/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/RolesTests.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Models;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Nancy;
 using Nancy.Testing;
 
@@ -20,8 +21,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         private readonly Browser _browser;
         private readonly string _securableItem;
         private readonly string _subjectId;
-        public RolesTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
+        public RolesTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory, ConnectionStrings connectionStrings = null)
         {
+            if (connectionStrings != null)
+            {
+                fixture.ConnectionStrings = connectionStrings;
+            }
             _securableItem = "rolesprincipal" + Guid.NewGuid();
             _subjectId = _securableItem;
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>

--- a/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
@@ -6,6 +6,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.API.Models;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using IdentityModel;
 using Nancy;
 using Nancy.Testing;
@@ -27,8 +28,12 @@ namespace Fabric.Authorization.IntegrationTests.Modules
 
         private readonly Browser _browser;
         private readonly string _securableItem;
-        public UserTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory)
+        public UserTests(IntegrationTestsFixture fixture, string storageProvider = StorageProviders.InMemory, ConnectionStrings connectionStrings = null)
         {
+            if (connectionStrings != null)
+            {
+                fixture.ConnectionStrings = connectionStrings;
+            }
             _securableItem = "userprincipal" + Guid.NewGuid();
             var principal = new ClaimsPrincipal(
                 new ClaimsIdentity(new List<Claim>

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerClientTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerClientTests.cs
@@ -8,9 +8,8 @@ namespace Fabric.Authorization.IntegrationTests.SqlServer
     [Collection("SqlServerTests")]
     public class SqlServerClientTests : ClientTests
     {
-        public SqlServerClientTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.SqlServer)
+        public SqlServerClientTests(IntegrationTestsFixture fixture, SqlServerIntegrationTestsFixture sqlFixture) : base(fixture, StorageProviders.SqlServer, sqlFixture.ConnectionStrings)
         {
-
         }
     }
 }

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerDosTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerDosTests.cs
@@ -3,14 +3,15 @@ using System.Collections.Generic;
 using System.Text;
 using Fabric.Authorization.API.Constants;
 using Fabric.Authorization.IntegrationTests.Modules;
+using Xunit;
 
 namespace Fabric.Authorization.IntegrationTests.SqlServer
 {
+    [Collection("SqlServerTests")]
     public class SqlServerDosTests : DosTests
     {
-        public SqlServerDosTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.SqlServer)
+        public SqlServerDosTests(IntegrationTestsFixture fixture, SqlServerIntegrationTestsFixture sqlFixture) : base(fixture, StorageProviders.SqlServer, sqlFixture.ConnectionStrings)
         {
-            
         }
     }
 }

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerGroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerGroupsTests.cs
@@ -7,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.SqlServer
     [Collection("SqlServerTests")]
     public class SqlServerGroupsTests : GroupsTests
     {
-        public SqlServerGroupsTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.SqlServer)
+        public SqlServerGroupsTests(IntegrationTestsFixture fixture, SqlServerIntegrationTestsFixture sqlFixture) : base(fixture, StorageProviders.SqlServer, sqlFixture.ConnectionStrings)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerIdentitySearchTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerIdentitySearchTests.cs
@@ -7,8 +7,9 @@ namespace Fabric.Authorization.IntegrationTests.SqlServer
     [Collection("SqlServerTests")]
     public class SqlServerIdentitySearchTests : IdentitySearchTests
     {
-        public SqlServerIdentitySearchTests(IdentitySearchFixture fixture) : base(fixture)
+        public SqlServerIdentitySearchTests(IdentitySearchFixture fixture, SqlServerIntegrationTestsFixture sqlFixture) : base(fixture)
         {
+            fixture.ConnectionStrings = sqlFixture.ConnectionStrings;
             Fixture.Initialize(StorageProviders.SqlServer);
         }
     }

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerPermissionsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerPermissionsTests.cs
@@ -7,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.SqlServer
     [Collection("SqlServerTests")]
     public class SqlServerPermissionsTests : PermissionsTests
     {
-        public SqlServerPermissionsTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.SqlServer)
+        public SqlServerPermissionsTests(IntegrationTestsFixture fixture, SqlServerIntegrationTestsFixture sqlFixture) : base(fixture, StorageProviders.SqlServer, sqlFixture.ConnectionStrings)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerRolesTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerRolesTests.cs
@@ -7,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.SqlServer
     [Collection("SqlServerTests")]
     public class SqlServerRolesTests : RolesTests
     {
-        public SqlServerRolesTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.SqlServer)
+        public SqlServerRolesTests(IntegrationTestsFixture fixture, SqlServerIntegrationTestsFixture sqlFixture) : base(fixture, StorageProviders.SqlServer, sqlFixture.ConnectionStrings)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerUserTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerUserTests.cs
@@ -7,7 +7,7 @@ namespace Fabric.Authorization.IntegrationTests.SqlServer
     [Collection("SqlServerTests")]
     public class SqlServerUserTests : UserTests
     {
-        public SqlServerUserTests(IntegrationTestsFixture fixture) : base(fixture, StorageProviders.SqlServer)
+        public SqlServerUserTests(IntegrationTestsFixture fixture, SqlServerIntegrationTestsFixture sqlFixture) : base(fixture, StorageProviders.SqlServer, sqlFixture.ConnectionStrings)
         {
         }
     }

--- a/Fabric.Authorization.IntegrationTests/SqlServerIntegrationTestsFixture.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServerIntegrationTestsFixture.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.IO;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
+using Xunit;
+
+namespace Fabric.Authorization.IntegrationTests
+{
+    public class SqlServerIntegrationTestsFixture : IDisposable
+    {
+        private string DatabaseNameSuffix { get; }
+        public ConnectionStrings ConnectionStrings { get; }
+
+        public SqlServerIntegrationTestsFixture()
+        {
+            DatabaseNameSuffix = GetDatabaseNameSuffix();
+            ConnectionStrings = GetSqlServerConnection(DatabaseNameSuffix);
+            CreateSqlServerDatabase();
+        }
+
+        private static readonly string SqlServerEnvironmentVariable = "SQLSERVERSETTINGS__SERVER";
+        private static readonly string SqlServerUsernameEnvironmentVariable = "SQLSERVERSETTINGS__USERNAME";
+        private static readonly string SqlServerPasswordEnvironmentVariable = "SQLSERVERSETTINGS__PASSWORD";
+
+        private string GetDatabaseNameSuffix()
+        {
+            var id = Guid.NewGuid().ToString().Replace("-", "");
+            return id;
+        }
+
+        private ConnectionStrings GetSqlServerConnection(string databaseNameSuffix)
+        {
+            var sqlServerHost = Environment.GetEnvironmentVariable(SqlServerEnvironmentVariable) ?? ".";
+            var sqlServerSecurityString = GetSqlServerSecurityString();
+            var connectionString = new ConnectionStrings
+            {
+                AuthorizationDatabase = $"Server={sqlServerHost};Database=Authorization-{databaseNameSuffix};{sqlServerSecurityString};MultipleActiveResultSets=true"
+            };
+
+            return connectionString;
+        }
+
+        private string GetSqlServerSecurityString()
+        {
+            var sqlServerUserName = Environment.GetEnvironmentVariable(SqlServerUsernameEnvironmentVariable);
+            var sqlServerPassword = Environment.GetEnvironmentVariable(SqlServerPasswordEnvironmentVariable);
+            var securityString = "Trusted_Connection=True";
+            if (!string.IsNullOrEmpty(sqlServerUserName) && !string.IsNullOrEmpty(sqlServerPassword))
+            {
+                securityString = $"User Id={sqlServerUserName};Password={sqlServerPassword}";
+            }
+            return securityString;
+        }
+
+        private void CreateSqlServerDatabase()
+        {
+            var targetDbName = $"Authorization-{DatabaseNameSuffix}";
+
+            var connection =
+                ConnectionStrings.AuthorizationDatabase.Replace(targetDbName, "master");
+            var file = new FileInfo("Fabric.Authorization.SqlServer_Create.sql");
+
+            var createDbScript = file.OpenText()
+                .ReadToEnd()
+                .Replace("$(DatabaseName)", targetDbName);
+
+            var splitter = new[] {"GO\r\n"};
+            var commandTexts = createDbScript.Split(splitter, StringSplitOptions.RemoveEmptyEntries);
+            int x;
+            using (var conn = new SqlConnection(connection))
+            {
+                conn.Open();
+                using (var command = new SqlCommand("query", conn))
+                {
+                    for (x = 0; x < commandTexts.Length; x++)
+                    {
+                        var commandText = commandTexts[x];
+
+                        // break if we just created the Identity DB
+                        if (commandText.StartsWith("CREATE DATABASE"))
+                        {
+                            var commandParts = commandText.Split(
+                                new[] {" ON "},
+                                StringSplitOptions.RemoveEmptyEntries);
+
+                            command.CommandText = commandParts[0];
+                            command.ExecuteNonQuery();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // establish a connection to the newly created Identity DB
+            using (var conn = new SqlConnection(ConnectionStrings.AuthorizationDatabase))
+            {
+                conn.Open();
+
+                using (var command = new SqlCommand("query", conn))
+                {
+                    for (x = x + 1; x < commandTexts.Length; x++)
+                    {
+                        var commandText = commandTexts[x];
+
+                        // skip generated SqlPackage commands and comments
+                        if (commandText.StartsWith(":") || commandText.StartsWith("/*"))
+                        {
+                            continue;
+                        }
+
+                        command.CommandText = commandText.Replace("HCFabricAuthorizationData1", "PRIMARY")
+                            .Replace("HCFabricAuthorizationIndex1", "PRIMARY")
+                            .TrimEnd(Environment.NewLine.ToCharArray());
+                        command.ExecuteNonQuery();
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            var targetDbName = $"Authorization-{DatabaseNameSuffix}";
+
+            var connection =
+                ConnectionStrings.AuthorizationDatabase.Replace(targetDbName, "master");
+            using (var conn = new SqlConnection(connection))
+            {
+                conn.Open();
+                using (var command = new SqlCommand($"ALTER DATABASE [{targetDbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE", conn))
+                {
+                    command.ExecuteNonQuery();
+                }
+                using (var command = new SqlCommand($"DROP DATABASE [{targetDbName}]", conn))
+                {
+                    command.ExecuteNonQuery();
+                }
+            }
+        }
+
+    }
+
+    [CollectionDefinition("SqlServerTests")]
+    public class SqlServerTestsCollection : ICollectionFixture<SqlServerIntegrationTestsFixture>
+    { }
+}


### PR DESCRIPTION
Our integration tests take over 6 minutes on the build server. Hopefully this will reduce that by not creating a database for every test class, and only creating a database per test run.

Also, added cleanup so we can potentially point the tests at a beefier sql server instance running on a VM instead of using a container on the build machine itself.