### PR TITLE
Update RolePermissionResolverService

### DIFF
--- a/Fabric.Authorization.Domain/Resolvers/Permissions/RolePermissionResolverService.cs
+++ b/Fabric.Authorization.Domain/Resolvers/Permissions/RolePermissionResolverService.cs
@@ -85,7 +85,7 @@ namespace Fabric.Authorization.Domain.Resolvers.Permissions
                                   StringComparison.OrdinalIgnoreCase) &&
                               u.IdentityProvider.Equals(permissionResolutionRequest.IdentityProvider,
                                   StringComparison.OrdinalIgnoreCase))) || role.IsDeleted ||
-                   role.Permissions == null;
+                   role.Permissions == null || role.Permissions.Count == 0;
         }
 
         private static void AddResolvedPermissions(

--- a/Fabric.Authorization.Domain/Resolvers/Permissions/RolePermissionResolverService.cs
+++ b/Fabric.Authorization.Domain/Resolvers/Permissions/RolePermissionResolverService.cs
@@ -30,7 +30,7 @@ namespace Fabric.Authorization.Domain.Resolvers.Permissions
 
             foreach (var role in roles)
             {
-                if (!role.Groups.Any(g => groupNames.Contains(g, StringComparer.OrdinalIgnoreCase)) || role.IsDeleted || role.Permissions == null)
+                if (BypassRoleEvaluation(role, groupNames, resolutionRequest))
                 {
                     continue;
                 }
@@ -76,6 +76,14 @@ namespace Fabric.Authorization.Domain.Resolvers.Permissions
                 AllowedPermissions = allowedPermissions.Distinct(),
                 DeniedPermissions = deniedPermissions.Distinct()
             };
+        }
+
+        private static bool BypassRoleEvaluation(Role role, List<string> groupNames, PermissionResolutionRequest permissionResolutionRequest)
+        {
+            return !(role.Groups.Any(g => groupNames.Contains(g, StringComparer.OrdinalIgnoreCase)) || role.Users.Any(
+                         u => u.SubjectId == permissionResolutionRequest.SubjectId &&
+                              u.IdentityProvider == permissionResolutionRequest.IdentityProvider)) || role.IsDeleted ||
+                   role.Permissions == null;
         }
 
         private static void AddResolvedPermissions(

--- a/Fabric.Authorization.Domain/Resolvers/Permissions/RolePermissionResolverService.cs
+++ b/Fabric.Authorization.Domain/Resolvers/Permissions/RolePermissionResolverService.cs
@@ -81,8 +81,10 @@ namespace Fabric.Authorization.Domain.Resolvers.Permissions
         private static bool BypassRoleEvaluation(Role role, List<string> groupNames, PermissionResolutionRequest permissionResolutionRequest)
         {
             return !(role.Groups.Any(g => groupNames.Contains(g, StringComparer.OrdinalIgnoreCase)) || role.Users.Any(
-                         u => u.SubjectId == permissionResolutionRequest.SubjectId &&
-                              u.IdentityProvider == permissionResolutionRequest.IdentityProvider)) || role.IsDeleted ||
+                         u => u.SubjectId.Equals(permissionResolutionRequest.SubjectId,
+                                  StringComparison.OrdinalIgnoreCase) &&
+                              u.IdentityProvider.Equals(permissionResolutionRequest.IdentityProvider,
+                                  StringComparison.OrdinalIgnoreCase))) || role.IsDeleted ||
                    role.Permissions == null;
         }
 

--- a/Fabric.Authorization.Persistence.SqlServer/EntityModels/Role.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/EntityModels/Role.cs
@@ -52,5 +52,8 @@ namespace Fabric.Authorization.Persistence.SqlServer.EntityModels
                 .Where(rp => rp.PermissionAction == PermissionAction.Deny
                              && !rp.IsDeleted)
                 .Select(rp => rp.Permission).ToList();
+
+        [NotMapped]
+        public ICollection<User> Users => RoleUsers.Where(ru => !ru.IsDeleted).Select(ru => ru.User).ToList();
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Mappers/RoleMapperProfile.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Mappers/RoleMapperProfile.cs
@@ -15,7 +15,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Mappers
                 .ForMember(x => x.ChildRoles, opt => opt.MapFrom(src => src.ChildRoles.Select(cr => cr.RoleId)))
                 .ForMember(x => x.Permissions, opt => opt.MapFrom(src => src.AllowedPermissions))
                 .ForMember(x => x.DeniedPermissions, opt => opt.MapFrom(src => src.DeniedPermissions))
-                .ForMember(x => x.Users, opt => opt.MapFrom(src => src.RoleUsers.Select(ru => ru.User)))
+                .ForMember(x => x.Users, opt => opt.MapFrom(src => src.Users))
                 .ReverseMap()
                 .ForMember(x => x.RoleId, opt => opt.MapFrom(src => src.Id))
                 .ForMember(x => x.ParentRoleId, opt => opt.MapFrom(src => src.ParentRole))

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerRoleStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerRoleStore.cs
@@ -144,12 +144,10 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
                 .Include(r => r.GroupRoles)
                 .ThenInclude(gr => gr.Group)
                 .Include(r => r.SecurableItem)
-                .Include(r => r.RolePermissions)
-                .ThenInclude(r => r.Permission)
-                .Include(r => r.GroupRoles)
-                .ThenInclude(g => g.Group)
                 .Include(r => r.ParentRole)
                 .Include(r => r.ChildRoles)
+                .Include(r => r.RoleUsers)
+                .ThenInclude(ru => ru.User)
                 .Where(r => !r.IsDeleted);
 
             if (!string.IsNullOrEmpty(grain))

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerUserStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerUserStore.cs
@@ -59,6 +59,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
 
             user.GroupUsers = user.GroupUsers.Where(gu => !gu.IsDeleted).ToList();
             user.UserPermissions = user.UserPermissions.Where(up => !up.IsDeleted).ToList();
+            user.RoleUsers = user.RoleUsers.Where(ru => !ru.IsDeleted).ToList();
 
             return user.ToModel();
         }

--- a/Fabric.Authorization.UnitTests/Resolvers/RolePermissionResolverServiceTests.cs
+++ b/Fabric.Authorization.UnitTests/Resolvers/RolePermissionResolverServiceTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Fabric.Authorization.Domain.Models;
+using Fabric.Authorization.Domain.Resolvers.Models;
+using Fabric.Authorization.Domain.Resolvers.Permissions;
+using Fabric.Authorization.Domain.Services;
+using Fabric.Authorization.Domain.Stores;
+using Fabric.Authorization.UnitTests.Mocks;
+using Moq;
+using Xunit;
+
+namespace Fabric.Authorization.UnitTests.Resolvers
+{
+    public class RolePermissionResolverServiceTests
+    {
+        [Fact]
+        public async Task Resolve_RoleUserPermissions_SuccessAsync()
+        {
+            var securableItem = "testapp";
+            var subjectId = "testuser";
+            var groups = new List<string> {"contributor"};
+            var roles = CreateRoles(securableItem, subjectId, groups);
+            var mockPermissionStore = new Mock<IPermissionStore>().Object;
+            var mockRoleStore = new Mock<IRoleStore>()
+                .SetupGetRoles(roles)
+                .Object;
+            var roleService = new RoleService(mockRoleStore, mockPermissionStore);
+            var resolverService = new RolePermissionResolverService(roleService);
+            var resolutionResult = await resolverService.Resolve(new PermissionResolutionRequest
+            {
+                Grain = Domain.Defaults.Authorization.AppGrain,
+                IdentityProvider = "Windows",
+                SecurableItem = securableItem,
+                SubjectId = subjectId,
+                UserGroups = groups,
+                IncludeSharedPermissions = false
+            });
+            Assert.Equal(2, resolutionResult.AllowedPermissions.Count());
+        }
+
+        private List<Role> CreateRoles(string securableItem, string subjectId, IList<string> groups)
+        {
+            var roles = new List<Role>
+            {
+                new Role
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "contributor",
+                    SecurableItem = securableItem,
+                    Grain = Domain.Defaults.Authorization.AppGrain,
+                    Groups = groups,
+                    Permissions = new List<Permission>
+                    {
+                        new Permission
+                        {
+                            Id = Guid.NewGuid(),
+                            SecurableItem = securableItem,
+                            Grain = Domain.Defaults.Authorization.AppGrain,
+                            Name = "edit"
+                        }
+                    }
+                },
+                new Role
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "read",
+                    SecurableItem = securableItem,
+                    Grain = Domain.Defaults.Authorization.AppGrain,
+                    Users = new List<User>
+                    {
+                        new User(subjectId, "Windows")
+                    },
+                    Permissions = new List<Permission>
+                    {
+                        new Permission
+                        {
+                            Id = Guid.NewGuid(),
+                            SecurableItem = securableItem,
+                            Grain = Domain.Defaults.Authorization.AppGrain,
+                            Name = "read"
+                        }
+                    }
+                },
+                new Role
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "admin",
+                    SecurableItem = securableItem,
+                    Grain = Domain.Defaults.Authorization.AppGrain,
+                    Users = new List<User>
+                    {
+                        new User(subjectId + Guid.NewGuid(), "Windows")
+                    },
+                    Permissions = new List<Permission>
+                    {
+                        new Permission
+                        {
+                            Id = Guid.NewGuid(),
+                            SecurableItem = securableItem,
+                            Grain = Domain.Defaults.Authorization.AppGrain,
+                            Name = "delete"
+                        }
+                    }
+                },
+                new Role
+                {
+                    Id = Guid.NewGuid(),
+                    Name = "owner",
+                    SecurableItem = securableItem,
+                    Grain = Domain.Defaults.Authorization.AppGrain,
+                    Groups = new List<string> {"admins"},
+                    Permissions = new List<Permission>
+                    {
+                        new Permission
+                        {
+                            Id = Guid.NewGuid(),
+                            SecurableItem = securableItem,
+                            Grain = Domain.Defaults.Authorization.AppGrain,
+                            Name = "takeownership"
+                        }
+                    }
+                }
+            };
+            return roles;
+        }
+    }
+}


### PR DESCRIPTION
Now that we can associate users directly to roles, the RolePermissionResolverService needs to check if the role is associated to the user when deciding whether to process it or not.