### PR TITLE
1) added FabricAuthMemberSearchService tests, 2) fixed test issues in…

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.spec.ts
@@ -70,7 +70,7 @@ fdescribe('FabricAuthGroupService', () => {
           assertMockGroupUsersResponse(returnedGroup);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/users`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/users`));
         expect(req.request.method).toBe("GET");      
         req.flush(mockGroupUsersResponse, {status: 200, statusText: 'OK'});        
         httpTestingController.verify();
@@ -93,7 +93,7 @@ fdescribe('FabricAuthGroupService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`));
         expect(req.request.method).toBe("GET");
         req.flush(null, {status: 404, statusText: 'Group not found'});        
         httpTestingController.verify();
@@ -112,7 +112,7 @@ fdescribe('FabricAuthGroupService', () => {
           assertMockGroupUsersResponse(returnedGroup);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`));
         expect(req.request.method).toBe("POST");
         req.flush(mockGroupUsersResponse, {status: 201, statusText: 'Created'});        
         httpTestingController.verify();
@@ -135,7 +135,7 @@ fdescribe('FabricAuthGroupService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`));
         expect(req.request.method).toBe("POST");
         req.flush(null, {status: 404, statusText: 'Group not found'});        
         httpTestingController.verify();
@@ -154,7 +154,7 @@ fdescribe('FabricAuthGroupService', () => {
           assertMockGroupUsersResponse(returnedGroup);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupUsersResponse.groupName}/users`));
         expect(req.request.method).toBe("DELETE");  
         req.flush(mockGroupUsersResponse, {status: 204, statusText: 'No Content'});        
         httpTestingController.verify();
@@ -177,7 +177,7 @@ fdescribe('FabricAuthGroupService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/users`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/users`));
         expect(req.request.method).toBe("DELETE");
         req.flush(null, {status: 404, statusText: 'Group not found'});        
         httpTestingController.verify();
@@ -196,7 +196,7 @@ fdescribe('FabricAuthGroupService', () => {
           assertMockGroupRolesResponse(returnedGroup);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`));
         expect(req.request.method).toBe("GET");      
         req.flush(mockGroupRolesResponse, {status: 200, statusText: 'OK'});        
         httpTestingController.verify();
@@ -219,7 +219,7 @@ fdescribe('FabricAuthGroupService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`));
         expect(req.request.method).toBe("GET");
         req.flush(null, {status: 404, statusText: 'Group not found'});        
         httpTestingController.verify();
@@ -238,7 +238,7 @@ fdescribe('FabricAuthGroupService', () => {
           assertMockGroupRolesResponse(returnedGroup);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`));
         expect(req.request.method).toBe("POST");      
         req.flush(mockGroupRolesResponse, {status: 201, statusText: 'Created'});
         httpTestingController.verify();
@@ -261,7 +261,7 @@ fdescribe('FabricAuthGroupService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`));
         expect(req.request.method).toBe("POST");
         req.flush(null, {status: 404, statusText: 'Group not found'});        
         httpTestingController.verify();
@@ -280,7 +280,7 @@ fdescribe('FabricAuthGroupService', () => {
           assertMockGroupRolesResponse(returnedGroup);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`));
         expect(req.request.method).toBe("DELETE");      
         req.flush(mockGroupRolesResponse, {status: 204, statusText: 'No Content'});        
         httpTestingController.verify();
@@ -303,7 +303,7 @@ fdescribe('FabricAuthGroupService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthGroupService.baseGroupApiUrl}/${mockGroupRolesResponse.groupName}/roles`));
         expect(req.request.method).toBe("DELETE");
         req.flush(null, {status: 404, statusText: 'Group not found'});        
         httpTestingController.verify();

--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.ts
@@ -73,7 +73,6 @@ export class FabricAuthGroupService extends FabricBaseService {
   }
 
   private replaceGroupNameSegment(tokenizedUrl: string, groupName: string): string {
-    return tokenizedUrl
-      .replace("{groupName}", encodeURI(groupName));
+    return encodeURI(tokenizedUrl.replace("{groupName}", groupName));
   }
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-member-search.service.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-member-search.service.spec.ts
@@ -1,28 +1,90 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed, inject } from '@angular/core/testing';
+import { Pipe, PipeTransform } from '@angular/core';
+import { TestBed, inject, async } from '@angular/core/testing';
+import { Observable } from 'rxjs/Rx';
 
-import { FabricAuthMemberSearchService } from '../services';
+import { FabricAuthMemberSearchService, AccessControlConfigService } from '../services';
+import { Group, User, Role, AuthMemberSearchRequest } from '../models';
+import { ErrorObservable } from 'rxjs/observable/ErrorObservable';
+import { FabricHttpErrorHandlerInterceptorService } from './interceptors/fabric-http-error-handler-interceptor.service';
 
-describe('FabricAuthMemberSearchService', () => {
-  let httpClient: HttpClient;
-  let httpTestingController: HttpTestingController;
+fdescribe('FabricAuthMemberSearchService', () => {
+
+  const mockAuthSearchResult = [
+    {
+      subjectId: 'sub123',
+      identityProvider: 'AD',
+      firstName: 'First',
+      lastName: 'Last',
+      roles: [
+        'admin',
+        'superuser'
+      ],
+      entityType: "user"
+    },
+    {
+      groupName: 'Group 1',
+      roles: [
+        'viewer'
+      ],
+      entityType: 'group'
+    }
+  ];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ HttpClientTestingModule ],
-      providers: [FabricAuthMemberSearchService]
+      providers: [
+        FabricAuthMemberSearchService,         
+        { provide: HTTP_INTERCEPTORS, useClass: FabricHttpErrorHandlerInterceptorService, multi: true },
+        AccessControlConfigService ]
     });
-
-    httpClient = TestBed.get(HttpClient);
-    httpTestingController = TestBed.get(HttpTestingController);
   });
 
   it('should be created', inject([FabricAuthMemberSearchService], (service: FabricAuthMemberSearchService) => {
     expect(service).toBeTruthy();
   }));
 
-  afterEach(() => {
-    httpTestingController.verify();
-  });
+  it('searchMembers should deserialize all properties',
+    async(  
+      inject([HttpClient, HttpTestingController, FabricAuthMemberSearchService], (
+        httpClient: HttpClient,
+        httpTestingController: HttpTestingController,
+        service: FabricAuthMemberSearchService) => {
+
+        let authSearchRequest = new AuthMemberSearchRequest();
+        authSearchRequest.clientId = 'atlas';
+        //authSearchRequest.pageNumber = 1;
+
+        service.searchMembers(authSearchRequest).subscribe(searchResults => {
+          expect(searchResults).toBeDefined();
+          expect(searchResults.length).toBe(2);
+
+          let result1 = searchResults[0];
+          expect(result1.subjectId).toBe('sub123');
+          expect(result1.identityProvider).toBe('AD');
+          expect(result1.firstName).toBe('First');
+          expect(result1.lastName).toBe('Last');
+          expect(result1.roles).toBeDefined();
+          expect(result1.roles.length).toBe(2);
+          expect(result1.roles[0]).toBe('admin');
+          expect(result1.roles[1]).toBe('superuser');
+          expect(result1.entityType).toBe('user');
+
+          let result2 = searchResults[1];
+          expect(result2.groupName).toBe('Group 1');
+          expect(result2.roles).toBeDefined();
+          expect(result2.roles.length).toBe(1);
+          expect(result2.roles[0]).toBe('viewer');
+          expect(result2.entityType).toBe('group');
+        });
+
+        const req = httpTestingController.expectOne(`${FabricAuthMemberSearchService.baseMemberSearchApiUrl}?clientId=atlas`);
+        expect(req.request.method).toBe("GET");      
+        req.flush(mockAuthSearchResult, {status: 200, statusText: 'OK'});
+        httpTestingController.verify();
+      })
+    )
+  );
 });

--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-member-search.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-member-search.service.ts
@@ -11,13 +11,13 @@ import { AccessControlConfigService } from './access-control-config.service';
 @Injectable()
 export class FabricAuthMemberSearchService extends FabricBaseService {
 
-  public static baseMemberApiUrl: string;
+  public static baseMemberSearchApiUrl: string;
 
   constructor(httpClient: HttpClient, accessControlConfigService: AccessControlConfigService) {
     super(httpClient, accessControlConfigService);
 
-    if (!FabricAuthMemberSearchService.baseMemberApiUrl) {
-      FabricAuthMemberSearchService.baseMemberApiUrl = `${accessControlConfigService.getFabricAuthApiUrl()}/members`;
+    if (!FabricAuthMemberSearchService.baseMemberSearchApiUrl) {
+      FabricAuthMemberSearchService.baseMemberSearchApiUrl = `${accessControlConfigService.getFabricAuthApiUrl()}/members`;
     }
   }
 
@@ -47,6 +47,6 @@ export class FabricAuthMemberSearchService extends FabricBaseService {
     }
 
     return this.httpClient
-      .get<AuthMemberSearchResult[]>(FabricAuthMemberSearchService.baseMemberApiUrl, {params});
+      .get<AuthMemberSearchResult[]>(FabricAuthMemberSearchService.baseMemberSearchApiUrl, {params});
   }
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-user.service.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-user.service.spec.ts
@@ -67,7 +67,7 @@ fdescribe('FabricAuthUserService', () => {
           assertMockUserGroupsResponse(returnedGroups);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/groups`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/groups`));
         expect(req.request.method).toBe("GET");      
         req.flush(mockUserGroupsResponse, {status: 200, statusText: 'OK'});        
         httpTestingController.verify();
@@ -90,7 +90,7 @@ fdescribe('FabricAuthUserService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/groups`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/groups`));
         expect(req.request.method).toBe("GET");
         req.flush(null, {status: 404, statusText: 'User not found'});        
         httpTestingController.verify();
@@ -132,7 +132,7 @@ fdescribe('FabricAuthUserService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`));
         expect(req.request.method).toBe("GET");
         req.flush(null, {status: 404, statusText: 'User not found'});        
         httpTestingController.verify();
@@ -151,7 +151,7 @@ fdescribe('FabricAuthUserService', () => {
           assertMockUserResponse(returnedUser);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`));
         expect(req.request.method).toBe("POST");      
         req.flush(mockUserResponse, {status: 201, statusText: 'Created'});
         httpTestingController.verify();
@@ -174,7 +174,7 @@ fdescribe('FabricAuthUserService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`));
         expect(req.request.method).toBe("POST");
         req.flush(null, {status: 404, statusText: 'User not found'});        
         httpTestingController.verify();
@@ -193,7 +193,7 @@ fdescribe('FabricAuthUserService', () => {
           assertMockUserResponse(returnedUser);
         });
 
-        const req = httpTestingController.expectOne(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`));
         expect(req.request.method).toBe("DELETE");      
         req.flush(mockUserResponse, {status: 204, statusText: 'No Content'});
         httpTestingController.verify();
@@ -216,7 +216,7 @@ fdescribe('FabricAuthUserService', () => {
         })
         .subscribe();
 
-        const req = httpTestingController.expectOne(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`);
+        const req = httpTestingController.expectOne(encodeURI(`${FabricAuthUserService.baseUserApiUrl}/${idP}/${subjectId}/roles`));
         expect(req.request.method).toBe("DELETE");
         req.flush(null, {status: 404, statusText: 'User not found'});        
         httpTestingController.verify();

--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-user.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-user.service.ts
@@ -52,8 +52,8 @@ export class FabricAuthUserService extends FabricBaseService {
   }
 
   private replaceUserIdSegment(tokenizedUrl: string, identityProvider: string, subjectId: string): string {
-    return tokenizedUrl
+    return encodeURI(tokenizedUrl
       .replace("{identityProvider}", identityProvider)
-      .replace("{subjectId}", encodeURI(subjectId));
+      .replace("{subjectId}", subjectId));
   }
 }


### PR DESCRIPTION
…troduced by URI encoding