### PR TITLE
throw exception from EF if local evaluation of a query is going to happen

### DIFF
--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -15,6 +15,7 @@ using Fabric.Platform.Bootstrappers.Nancy;
 using LibOwin;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Nancy;
 using Nancy.Bootstrapper;
@@ -23,24 +24,26 @@ using Nancy.Owin;
 using Nancy.Responses.Negotiation;
 using Nancy.Swagger.Services;
 using Nancy.TinyIoc;
-using Serilog;
 using Serilog.Core;
 using Swagger.ObjectModel;
 using Swagger.ObjectModel.Builders;
 using HttpResponseHeaders = Fabric.Authorization.API.Constants.HttpResponseHeaders;
+using ILogger = Serilog.ILogger;
 
 namespace Fabric.Authorization.API
 {
     public class Bootstrapper : DefaultNancyBootstrapper
     {
         private readonly IHostingEnvironment _env;
+        private readonly ILoggerFactory _loggerFactory;
         private readonly IAppConfiguration _appConfig;
         private readonly ILogger _logger;
         private readonly LoggingLevelSwitch _loggingLevelSwitch;
 
-        public Bootstrapper(ILogger logger, IAppConfiguration appConfig, LoggingLevelSwitch levelSwitch, IHostingEnvironment env)
+        public Bootstrapper(ILogger logger, IAppConfiguration appConfig, LoggingLevelSwitch levelSwitch, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             _env = env;
+            _loggerFactory = loggerFactory;
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _appConfig = appConfig ?? throw new ArgumentNullException(nameof(appConfig));
             _loggingLevelSwitch = levelSwitch ?? throw new ArgumentNullException(nameof(levelSwitch));
@@ -132,6 +135,7 @@ namespace Fabric.Authorization.API
         private void ConfigureApplicationRegistrations(TinyIoCContainer container)
         {
             container.Register(_appConfig);
+            container.Register(_loggerFactory);
             container.Register(_logger);
             var options = new MemoryCacheOptions();
             var eventLogger = LogFactory.CreateEventLogger(_loggingLevelSwitch, _appConfig.ApplicationInsights);

--- a/Fabric.Authorization.API/Fabric.Authorization.API.csproj
+++ b/Fabric.Authorization.API/Fabric.Authorization.API.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.5" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="1.1.2" />
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
     <PackageReference Include="Nancy.Swagger" Version="2.2.29-alpha" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />

--- a/Fabric.Authorization.API/Startup.cs
+++ b/Fabric.Authorization.API/Startup.cs
@@ -63,7 +63,7 @@ namespace Fabric.Authorization.API
                 .UseOwin()
                 .UseFabricLoggingAndMonitoring(_logger, HealthCheck, _levelSwitch)
                 .UseAuthPlatform(_idServerSettings.Scopes, _allowedPaths)
-                .UseNancy(opt => opt.Bootstrapper = new Bootstrapper(_logger, _appConfig, _levelSwitch, env));
+                .UseNancy(opt => opt.Bootstrapper = new Bootstrapper(_logger, _appConfig, _levelSwitch, env, loggerFactory));
         }
 
         // TODO: make this DB-agnostic

--- a/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/UserTests.cs
@@ -733,7 +733,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
                 with.JsonBody(perms);
             });
 
-            var postResponse = await _browser.Post($"/user/{IdentityProvider}/{subjectId.ToUpper()}/permissions", with =>
+            var postResponse = await _browser.Post($"/user/{IdentityProvider}/{subjectId}/permissions", with =>
             {
                 with.HttpRequest();
                 var perms = new List<PermissionApiModel> { modifyPatientPermission };

--- a/Fabric.Authorization.IntegrationTests/TestBootstrapper.cs
+++ b/Fabric.Authorization.IntegrationTests/TestBootstrapper.cs
@@ -22,7 +22,7 @@ namespace Fabric.Authorization.IntegrationTests
             IHostingEnvironment env, 
             ClaimsPrincipal principal, 
             IIdentityServiceProvider identityServiceProvider = null)
-            : base(logger, appConfig, levelSwitch, env)
+            : base(logger, appConfig, levelSwitch, env, null)
         {
             _principal = principal;
             _identityServiceProvider = identityServiceProvider;

--- a/Fabric.Authorization.Persistence.SqlServer/Services/InMemoryAuthorizationDbContext.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Services/InMemoryAuthorizationDbContext.cs
@@ -1,12 +1,14 @@
 ﻿using Fabric.Authorization.Domain.Services;
 using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Fabric.Authorization.Persistence.SqlServer.Services
 {
     public class InMemoryAuthorizationDbContext : AuthorizationDbContext
     {
-        public InMemoryAuthorizationDbContext(IEventContextResolverService eventContextResolverService, ConnectionStrings connectionStrings) : base(eventContextResolverService, connectionStrings)
+        public InMemoryAuthorizationDbContext(IEventContextResolverService eventContextResolverService, ConnectionStrings connectionStrings, ILoggerFactory loggerFactory) 
+            : base(eventContextResolverService, connectionStrings, loggerFactory)
         {
         }
 

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerClientStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerClientStore.cs
@@ -47,7 +47,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         {
             var client = await _authorizationDbContext.Clients
                 .Include(i => i.TopLevelSecurableItem)
-                .SingleOrDefaultAsync(c => c.ClientId.Equals(id, StringComparison.OrdinalIgnoreCase)
+                .SingleOrDefaultAsync(c => c.ClientId == id
                                            && !c.IsDeleted);
 
             if (client == null)
@@ -71,7 +71,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         {
             var client = await _authorizationDbContext.Clients
                 .Include(i => i.TopLevelSecurableItem)
-                .SingleOrDefaultAsync(c => c.ClientId.Equals(model.Id, StringComparison.OrdinalIgnoreCase)
+                .SingleOrDefaultAsync(c => c.ClientId == model.Id
                                            && !c.IsDeleted);
 
             if (client == null)
@@ -98,7 +98,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         {
             var client = await _authorizationDbContext.Clients
                 .Include(i => i.TopLevelSecurableItem)
-                .SingleOrDefaultAsync(c => c.ClientId.Equals(model.Id, StringComparison.OrdinalIgnoreCase)
+                .SingleOrDefaultAsync(c => c.ClientId == model.Id
                                            && !c.IsDeleted);
             if (client == null)
             {
@@ -119,7 +119,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         public async Task<bool> Exists(string id)
         {
             var client = await _authorizationDbContext.Clients                
-                .SingleOrDefaultAsync(c => c.ClientId.Equals(id, StringComparison.OrdinalIgnoreCase)
+                .SingleOrDefaultAsync(c => c.ClientId == id
                                            && !c.IsDeleted).ConfigureAwait(false);
 
             return client != null;

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
@@ -55,7 +55,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
                 .ThenInclude(gr => gr.Role)
                 .ThenInclude(r => r.SecurableItem)
                 .AsNoTracking()
-                .SingleOrDefaultAsync(g => g.Name.Equals(name, StringComparison.OrdinalIgnoreCase)
+                .SingleOrDefaultAsync(g => g.Name == name
                                            && !g.IsDeleted);
 
             if (group == null)
@@ -144,7 +144,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         public async Task<bool> Exists(string name)
         {
             var group = await _authorizationDbContext.Groups
-                .SingleOrDefaultAsync(g => g.Name.Equals(name, StringComparison.OrdinalIgnoreCase)
+                .SingleOrDefaultAsync(g => g.Name == name
                                            && !g.IsDeleted).ConfigureAwait(false);
 
             return group != null;
@@ -153,7 +153,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         public async Task<Group> AddRolesToGroup(Group group, IEnumerable<Role> rolesToAdd)
         {
             var groupEntity = await _authorizationDbContext.Groups.SingleOrDefaultAsync(g =>
-                g.Name.Equals(group.Name, StringComparison.OrdinalIgnoreCase)
+                g.Name == group.Name
                 && !g.IsDeleted);
 
             if (groupEntity == null)
@@ -231,7 +231,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         public async Task<Group> AddUsersToGroup(Group group, IEnumerable<User> usersToAdd)
         {
             var groupEntity = await _authorizationDbContext.Groups.SingleOrDefaultAsync(g =>
-                g.Name.Equals(group.Name, StringComparison.OrdinalIgnoreCase)
+                g.Name == group.Name
                 && !g.IsDeleted);
 
             if (groupEntity == null)
@@ -257,8 +257,8 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
         {
             var userInGroup = await _authorizationDbContext.GroupUsers
                 .SingleOrDefaultAsync(gu =>
-                    gu.SubjectId.Equals(user.SubjectId, StringComparison.OrdinalIgnoreCase) &&
-                    gu.IdentityProvider.Equals(user.IdentityProvider, StringComparison.OrdinalIgnoreCase) &&
+                    gu.SubjectId == user.SubjectId &&
+                    gu.IdentityProvider == user.IdentityProvider &&
                     gu.GroupId == Guid.Parse(group.Id));
 
             if (userInGroup != null)

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerRoleStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerRoleStore.cs
@@ -161,17 +161,17 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
 
             if (!string.IsNullOrEmpty(grain))
             {
-                roles = roles.Where(r => string.Equals(r.Grain, grain, StringComparison.OrdinalIgnoreCase));
+                roles = roles.Where(r => r.Grain == grain);
             }
 
             if (!string.IsNullOrWhiteSpace(securableItem))
             {
-                roles = roles.Where(r => string.Equals(r.SecurableItem.Name, securableItem));
+                roles = roles.Where(r => r.SecurableItem.Name == securableItem);
             }
 
             if (!string.IsNullOrWhiteSpace(roleName))
             {
-                roles = roles.Where(r => string.Equals(r.Name, roleName));
+                roles = roles.Where(r => r.Name == roleName);
             }
 
             foreach (var role in roles)

--- a/Fabric.Authorization.UnitTests/DbBootstrappers/SqlServerDbBootstrapperTests.cs
+++ b/Fabric.Authorization.UnitTests/DbBootstrappers/SqlServerDbBootstrapperTests.cs
@@ -70,7 +70,7 @@ namespace Fabric.Authorization.UnitTests.DbBootstrappers
 
         private InMemoryAuthorizationDbContext CreateDbContext()
         {
-            return new InMemoryAuthorizationDbContext(new NoOpEventContextResolverService(), new ConnectionStrings { AuthorizationDatabase = "somestring" });
+            return new InMemoryAuthorizationDbContext(new NoOpEventContextResolverService(), new ConnectionStrings { AuthorizationDatabase = "somestring" }, null);
         }
     }
 }


### PR DESCRIPTION
update all sql stores to remove code that will cause a client evaluation. some of the things that needed to be fixed: 
- dont call any methods on the string object inside a lambda used for filtering an EF query ( string.equals(a,b)
- create local variables when accessing items from an array, pass the local variables to the query ( dont grab an item from an array by index )
- dont use linq projections inside a query ( coll.Select(f => f.id).contains(bar) )   

i also enabled EF query logging 