### PR TITLE
Adding upgrade functionality to move EDWAdmin roles to Fabric.Auth roles

### DIFF
--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -2,35 +2,32 @@
 # Install_Authorization_Windows.ps1
 #
 param([switch]$noDiscoveryService)
-function Get-DiscoveryServiceUrl()
-{
+function Get-DiscoveryServiceUrl() {
     return "https://$env:computername.$($env:userdnsdomain.tolower())/DiscoveryService"
 }
 
-function Get-IdentityServiceUrl()
-{
+function Get-IdentityServiceUrl() {
     return "https://$env:computername.$($env:userdnsdomain.tolower())/Identity"
 }
 
-function Get-Headers($accessToken){
+function Get-Headers($accessToken) {
     $headers = @{"Accept" = "application/json"}
-    if($accessToken){
+    if ($accessToken) {
         $headers.Add("Authorization", "Bearer $accessToken")
     }
     return $headers
 }
 
-function Add-DiscoveryRegistration($discoveryUrl, $serviceUrl, $credential)
-{	
+function Add-DiscoveryRegistration($discoveryUrl, $serviceUrl, $credential) {	
     $registrationBody = @{
-        ServiceName = "AuthorizationService"
-        Version = 1
-        ServiceUrl = $serviceUrl
+        ServiceName   = "AuthorizationService"
+        Version       = 1
+        ServiceUrl    = $serviceUrl
         DiscoveryType = "Service"
-        IsHidden = $true
-        FriendlyName = "Fabric.Authorization"
-        Description = "The Fabric.Authorization service provides centralized authorization across the Fabric ecosystem."
-        BuildNumber = "1.1.2017120101"
+        IsHidden      = $true
+        FriendlyName  = "Fabric.Authorization"
+        Description   = "The Fabric.Authorization service provides centralized authorization across the Fabric ecosystem."
+        BuildNumber   = "1.1.2017120101"
     }
 
 	$url = "$discoveryUrl/v1/Services"
@@ -49,9 +46,8 @@ function Add-DiscoveryRegistration($discoveryUrl, $serviceUrl, $credential)
 	}
 }
 
-function Add-DatabaseLogin($userName, $connString)
-{
-	$query = "USE master
+function Add-DatabaseLogin($userName, $connString) {
+    $query = "USE master
 			If Not exists (SELECT * FROM sys.server_principals
 				WHERE sid = suser_sid(@userName))
 			BEGIN
@@ -60,54 +56,49 @@ function Add-DatabaseLogin($userName, $connString)
                 set @sql = 'CREATE LOGIN ' + QUOTENAME('$userName') + ' FROM WINDOWS'
                 EXEC sp_executesql @sql
 			END"
-	Invoke-Sql $connString $query @{userName=$userName} | Out-Null
+    Invoke-Sql $connString $query @{userName = $userName} | Out-Null
 }
 
-function Add-DatabaseUser($userName, $connString)
-{
-	$query = "IF( NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = @userName))
+function Add-DatabaseUser($userName, $connString) {
+    $query = "IF( NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = @userName))
 			BEGIN
 				print '-- Creating user';
 				DECLARE @sql nvarchar(4000)
                 set @sql = 'CREATE USER ' + QUOTENAME('$userName') + ' FOR LOGIN ' + QUOTENAME('$userName')
                 EXEC sp_executesql @sql
 			END"
-	Invoke-Sql $connString $query @{userName=$userName} | Out-Null
+    Invoke-Sql $connString $query @{userName = $userName} | Out-Null
 }
 
-function Add-DatabaseUserToRole($userName, $connString, $role)
-{
-	$query = "DECLARE @exists int
+function Add-DatabaseUserToRole($userName, $connString, $role) {
+    $query = "DECLARE @exists int
 			SELECT @exists = IS_ROLEMEMBER(@role, @userName) 
 			IF (@exists IS NULL OR @exists = 0)
 			BEGIN
 				print '-- Adding @role to @userName';
 				EXEC sp_addrolemember @role, @userName;
 			END"
-	Invoke-Sql $connString $query @{userName=$userName; role=$role} | Out-Null
+    Invoke-Sql $connString $query @{userName = $userName; role = $role} | Out-Null
 }
 
-function Add-DatabaseSecurity($userName, $role, $connString)
-{
-	Add-DatabaseLogin $userName $connString
-	Add-DatabaseUser $userName $connString
-	Add-DatabaseUserToRole $userName $connString $role
-	Write-Success "Database security applied successfully"
+function Add-DatabaseSecurity($userName, $role, $connString) {
+    Add-DatabaseLogin $userName $connString
+    Add-DatabaseUser $userName $connString
+    Add-DatabaseUserToRole $userName $connString $role
+    Write-Success "Database security applied successfully"
 }
 
-function Invoke-Get($url, $accessToken)
-{
+function Invoke-Get($url, $accessToken) {
     $headers = Get-Headers -accessToken $accessToken
         
     $getResponse = Invoke-RestMethod -Method Get -Uri $url -Headers $headers
     return $getResponse
 }
 
-function Invoke-Post($url, $body, $accessToken)
-{
+function Invoke-Post($url, $body, $accessToken) {
     $headers = Get-Headers -accessToken $accessToken
 
-    if(!($body -is [String])){
+    if (!($body -is [String])) {
         $body = (ConvertTo-Json $body)
     }
     
@@ -117,33 +108,34 @@ function Invoke-Post($url, $body, $accessToken)
     return $postResponse
 }
 
-function Get-Role($name, $grain, $securableItem, $authorizationServiceUrl, $accessToken){
+function Get-Role($name, $grain, $securableItem, $authorizationServiceUrl, $accessToken) {
     $url = "$authorizationServiceUrl/roles/$grain/$securableItem/$name"
     $role = Invoke-Get -url $url -accessToken $accessToken
     return $role
 }
 
-function Add-Group($authUrl, $name, $source, $accessToken){
+function Add-Group($authUrl, $name, $source, $accessToken) {
+    Write-Host "Adding Group $($name)"
     $url = "$authUrl/groups"
     $body = @{
-        id = "$name"
-        groupName = "$name"
+        id          = "$name"
+        groupName   = "$name"
         groupSource = "$source"
     }
     return Invoke-Post $url $body $accessToken
 }
 
-function Add-User($authUrl, $name, $accessToken){
-    Write-Host "Adding User"
+function Add-User($authUrl, $name, $accessToken) {
+    Write-Host "Adding User $($name)"
     $url = "$authUrl/user"
     $body = @{
-        subjectId = "$name"
+        subjectId        = "$name"
         identityProvider = "Windows"
     }
     return Invoke-Post $url $body $accessToken
 }
 
-function Add-RoleToUser($role, $user, $connString){
+function Add-RoleToUser($role, $user, $connString) {
     $query = "INSERT INTO RoleUsers
               (CreatedBy, CreatedDateTimeUtc, RoleId, IdentityProvider, IsDeleted, SubjectId)
               VALUES('fabric-installer', GetUtcDate(), @roleId, @identityProvider, 0, @subjectId)"
@@ -151,47 +143,47 @@ function Add-RoleToUser($role, $user, $connString){
     $roleId = $role.Id
     $identityProvider = $user.identityProvider
     $subjectId = $user.subjectId
-    Invoke-Sql $connString $query @{roleId=$roleId; identityProvider=$identityProvider; subjectId=$subjectId} | Out-Null
+    Invoke-Sql $connString $query @{roleId = $roleId; identityProvider = $identityProvider; subjectId = $subjectId} | Out-Null
 }
 
-function Add-RoleToGroup($role, $group, $connString){
+function Add-RoleToGroup($role, $group, $connString) {
     $query = "INSERT INTO GroupRoles
               (CreatedBy, CreatedDateTimeUtc, GroupId, IsDeleted, RoleId)
               VALUES('fabric-installer', GetUtcDate(), @groupId, 0, @roleId)"
 
     $roleId = $role.Id
     $groupId = $group.Id
-    Invoke-Sql $connString $query @{groupId=$groupId; roleId=$roleId;} | Out-Null
+    Invoke-Sql $connString $query @{groupId = $groupId; roleId = $roleId; } | Out-Null
 }
 
-function Get-PrincipalContext($domain){
+function Get-PrincipalContext($domain) {
     [System.Reflection.Assembly]::LoadWithPartialName("System.DirectoryServices.AccountManagement") | Out-Null
     $ct = [System.DirectoryServices.AccountManagement.ContextType]::Domain 
     $pc = New-Object System.DirectoryServices.AccountManagement.PrincipalContext -ArgumentList $ct, $domain
     return $pc
 }
 
-function Test-IsUser($samAccountName, $domain){
+function Test-IsUser($samAccountName, $domain) {
     $isUser = $false
     $pc = Get-PrincipalContext -domain $domain
     $user = [System.DirectoryServices.AccountManagement.UserPrincipal]::FindByIdentity($pc, $samAccountName)
-    if($user -ne $null){
+    if ($user -ne $null) {
         $isUser = $true
     }
     return $isUser
 }
 
-function Test-IsGroup($samAccountName, $domain){
+function Test-IsGroup($samAccountName, $domain) {
     $isGroup = $false
     $pc = Get-PrincipalContext -domain $domain
     $group = [System.DirectoryServices.AccountManagement.GroupPrincipal]::FindByIdentity($pc, $samAccountName)
-    if($group -ne $null){
+    if ($group -ne $null) {
         $isGroup = $true
     }
     return $isGroup
 }
 
-function Get-SamAccountFromAccountName($accountName){
+function Get-SamAccountFromAccountName($accountName) {
     $accountNameParts = $accountName.Split('\')
     if($accountNameParts.Count -ne 2){
         Write-Error "Please enter an account in the form DOMAIN\account. Halting installation." 
@@ -201,39 +193,42 @@ function Get-SamAccountFromAccountName($accountName){
     return $samAccountName
 }
 
-function Add-AccountToDosAdminRole($accountName, $domain, $authorizationServiceUrl, $accessToken, $connString){
+function Add-AccountToDosAdminRole($accountName, $domain, $authorizationServiceUrl, $accessToken, $connString) {
     $samAccountName = Get-SamAccountFromAccountName -accountName $accountName
     $role = Get-Role -name "dosadmin" -grain "dos" -securableItem "datamarts" -authorizationServiceUrl $authorizationServiceUrl -accessToken $accessToken
-    if(Test-IsUser -samAccountName $samAccountName -domain $domain){
-        try{
+    if (Test-IsUser -samAccountName $samAccountName -domain $domain) {
+        try {
             $user = Add-User -authUrl $authorizationServiceUrl -name $accountName -accessToken $accessToken
             Add-RoleToUser -role $role -user $user -connString $connString
-        }catch{
+        }
+        catch {
             $exception = $_.Exception
-            if($exception -ne $null -and $exception.Response -ne $null -and $exception.Response.StatusCode.value__ -eq 409)
-            {
+            if ($exception -ne $null -and $exception.Response -ne $null -and $exception.Response.StatusCode.value__ -eq 409) {
                 Write-Success "    User: $accountName has already been registered as dosadmin with Fabric.Authorization"
                 Write-Host ""
-            }else{
-                if($exception.Response -ne $null){
+            }
+            else {
+                if ($exception.Response -ne $null) {
                     $error = Get-ErrorFromResponse -response $exception.Response
                     Write-Error "    There was an error updating the resource: $error. Halting installation."
                 }
                 throw $exception
             }
         }
-    }elseif(Test-IsGroup -samAccountName $samAccountName -domain $domain){
-        try{
+    }
+    elseif (Test-IsGroup -samAccountName $samAccountName -domain $domain) {
+        try {
             $group = Add-Group -authUrl $authorizationServiceUrl -name $accountName -source "Windows" -accessToken $accessToken
             Add-RoleToGroup -role $role -group $group -connString $connString
-        }catch{
+        }
+        catch {
             $exception = $_.Exception
-            if($exception -ne $null -and $exception.Response -ne $null -and $exception.Response.StatusCode.value__ -eq 409)
-            {
+            if ($exception -ne $null -and $exception.Response -ne $null -and $exception.Response.StatusCode.value__ -eq 409) {
                 Write-Success "    Group: $accountName has already been registered as dosadmin with Fabric.Authorization"
                 Write-Host ""
-            }else{
-                if($exception.Response -ne $null){
+            }
+            else {
+                if ($exception.Response -ne $null) {
                     $error = Get-ErrorFromResponse -response $exception.Response
                     Write-Error "    There was an error updating the resource: $error. Halting installation."
                 }
@@ -246,8 +241,7 @@ function Add-AccountToDosAdminRole($accountName, $domain, $authorizationServiceU
     }
 }
 
-function Get-ErrorFromResponse($response)
-{
+function Get-ErrorFromResponse($response) {
     $result = $response.GetResponseStream()
     $reader = New-Object System.IO.StreamReader($result)
     $reader.BaseStream.Position = 0
@@ -256,14 +250,34 @@ function Get-ErrorFromResponse($response)
     return $responseBody
 }
 
-function Invoke-MonitorShallow($authorizationUrl)
-{
-	$url = "$authorizationUrl/_monitor/shallow"
-	Invoke-RestMethod -Method Get -Uri $url
+function Invoke-MonitorShallow($authorizationUrl) {
+    $url = "$authorizationUrl/_monitor/shallow"
+    Invoke-RestMethod -Method Get -Uri $url
 }
 
-if(!(Test-Path .\Fabric-Install-Utilities.psm1)){
-	Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -OutFile Fabric-Install-Utilities.psm1
+function Get-EdwAdminUsersAndGroups() {
+    $results = Invoke-Sqlcmd -Query "
+        SELECT i.IdentityID, i.IdentityNM, r.RoleNM
+        FROM [EDWAdmin].[CatalystAdmin].[RoleBASE] r
+        INNER JOIN [EDWAdmin].[CatalystAdmin].[IdentityRoleBASE] ir
+            ON r.RoleID = ir.RoleID
+        INNER JOIN [EDWAdmin].[CatalystAdmin].[IdentityBASE] i
+            ON ir.IdentityID = i.IdentityID
+        WHERE RoleNM = 'EDW Admin'";
+
+    return $results;
+}
+
+function Add-UsersAndGroupsToDosAdminRole($edwAdminUsersAndGroups, $domain, $connString) {
+
+    foreach ($edwAdmin in $edwAdminUsersAndGroups) {
+        Add-AccountToDosAdminRole -accountName $edwAdmin.IdentityNM -domain $domain -authorizationServiceUrl "$authorizationServiceUrl/v1" -accessToken $accessToken -connString $authorizationDbConnStr
+    }
+}
+
+
+if (!(Test-Path .\Fabric-Install-Utilities.psm1)) {
+    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -OutFile Fabric-Install-Utilities.psm1
 }
 Import-Module -Name .\Fabric-Install-Utilities.psm1 -Force
 
@@ -288,43 +302,39 @@ $authorizationDbName = $installSettings.authorizationDbName
 $authorizationDatabaseRole = $installSettings.authorizationDatabaseRole
 $fabricInstallerSecret = $installSettings.fabricInstallerSecret
 $hostUrl = $installSettings.hostUrl
-$authorizationServiceUrl =  $installSettings.authorizationSerivce
+$authorizationServiceUrl = $installSettings.authorizationSerivce
 $storedIisUser = $installSettings.iisUser
 $adminAccount = $installSettings.adminAccount
 $currentUserDomain = $env:userdnsdomain
 $workingDirectory = Get-CurrentScriptDirectory
 
-if([string]::IsNullOrEmpty($installSettings.discoveryService))  
-{
-	$discoveryServiceUrl = Get-DiscoveryServiceUrl
-} else
-{
-	$discoveryServiceUrl = $installSettings.discoveryService
+if ([string]::IsNullOrEmpty($installSettings.discoveryService)) {
+    $discoveryServiceUrl = Get-DiscoveryServiceUrl
+}
+else {
+    $discoveryServiceUrl = $installSettings.discoveryService
 }
 
-if([string]::IsNullOrEmpty($installSettings.identityService))  
-{
-	$identityServerUrl = Get-IdentityServiceUrl
-} else
-{
-	$identityServerUrl = $installSettings.identityService
+if ([string]::IsNullOrEmpty($installSettings.identityService)) {
+    $identityServerUrl = Get-IdentityServiceUrl
+}
+else {
+    $identityServerUrl = $installSettings.identityService
 }
 
-if([string]::IsNullOrEmpty($installSettings.authorizationSerivce))  
-{
-	$authorizationServiceUrl = "https://$env:computername.$($env:userdnsdomain.tolower())/Authorization"
-} else
-{
-	$authorizationServiceUrl = $installSettings.authorizationSerivce
+if ([string]::IsNullOrEmpty($installSettings.authorizationSerivce)) {
+    $authorizationServiceUrl = "https://$env:computername.$($env:userdnsdomain.tolower())/Authorization"
+}
+else {
+    $authorizationServiceUrl = $installSettings.authorizationSerivce
 }
 
 Write-Host ""
 Write-Host "Checking prerequisites..."
 Write-Host ""
 
-if(!(Test-PrerequisiteExact "*.NET Core*Windows Server Hosting*" 1.1.30503.82))
-{    
-    try{
+if (!(Test-PrerequisiteExact "*.NET Core*Windows Server Hosting*" 1.1.30503.82)) {    
+    try {
         Write-Console "Windows Server Hosting Bundle version 1.1.30503.82 not installed...installing version 1.1.30503.82"        
         Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=848766 -OutFile $env:Temp\bundle.exe
         Start-Process $env:Temp\bundle.exe -Wait -ArgumentList '/quiet /install'
@@ -334,15 +344,17 @@ if(!(Test-PrerequisiteExact "*.NET Core*Windows Server Hosting*" 1.1.30503.82))
         Write-Error "Could not install .NET Windows Server Hosting bundle. Please install the hosting bundle before proceeding. https://go.microsoft.com/fwlink/?linkid=844461."
         throw
     }
-    try{
+    try {
         Remove-Item $env:Temp\bundle.exe
-    }catch{        
+    }
+    catch {        
         $e = $_.Exception        
         Write-Warning "Unable to remove Server Hosting bundle exe" 
         Write-Warning $e.Message
     }
 
-}else{
+}
+else {
     Write-Success ".NET Core Windows Server Hosting Bundle installed and meets expectations."
     Write-Host ""
 }
@@ -352,22 +364,23 @@ if(!(Test-Prerequisite "*IIS URL Rewrite Module 2" 7.2.1952)){
     throw
 }
 
-try{
+try {
     $sites = Get-ChildItem IIS:\Sites
-    if($sites -is [array]){
+    if ($sites -is [array]) {
         $sites |
             ForEach-Object {New-Object PSCustomObject -Property @{
-                'Id'=$_.id;
-                'Name'=$_.name;
-                'Physical Path'=[System.Environment]::ExpandEnvironmentVariables($_.physicalPath);
-                'Bindings'=$_.bindings;
-            };} |
-            Format-Table Id,Name,'Physical Path',Bindings -AutoSize
+                'Id'            = $_.id;
+                'Name'          = $_.name;
+                'Physical Path' = [System.Environment]::ExpandEnvironmentVariables($_.physicalPath);
+                'Bindings'      = $_.bindings;
+            }; } |
+            Format-Table Id, Name, 'Physical Path', Bindings -AutoSize
 
         $selectedSiteId = Read-Host "Select a web site by Id"
         Write-Host ""
         $selectedSite = $sites[$selectedSiteId - 1]
-    }else{
+    }
+    else {
         $selectedSite = $sites
     }
 
@@ -379,22 +392,21 @@ try{
     throw
 }
 
-if([string]::IsNullOrEmpty($encryptionCertificateThumbprint))
-{
-	try{
+if ([string]::IsNullOrEmpty($encryptionCertificateThumbprint)) {
+    try {
 
-		$allCerts = Get-CertsFromLocation Cert:\LocalMachine\My
-		$index = 1
-		$allCerts |
-			ForEach-Object {New-Object PSCustomObject -Property @{
-			'Index'=$index;
-			'Subject'= $_.Subject; 
-			'Name' = $_.FriendlyName; 
-			'Thumbprint' = $_.Thumbprint; 
-			'Expiration' = $_.NotAfter
-			};
-			$index ++} |
-			Format-Table Index,Name,Subject,Expiration,Thumbprint  -AutoSize
+        $allCerts = Get-CertsFromLocation Cert:\LocalMachine\My
+        $index = 1
+        $allCerts |
+            ForEach-Object {New-Object PSCustomObject -Property @{
+                'Index'      = $index;
+                'Subject'    = $_.Subject; 
+                'Name'       = $_.FriendlyName; 
+                'Thumbprint' = $_.Thumbprint; 
+                'Expiration' = $_.NotAfter
+            };
+            $index ++} |
+            Format-Table Index, Name, Subject, Expiration, Thumbprint  -AutoSize
 
 		$selectionNumber = Read-Host  "Select an encryption certificate by Index"
 		Write-Host ""
@@ -418,67 +430,68 @@ if([string]::IsNullOrEmpty($encryptionCertificateThumbprint))
 
 }
 
-try{
-	$encryptionCert = Get-Certificate $encryptionCertificateThumbprint
-}catch{
-	Write-Host "Could not get encryption certificate with thumbprint $encryptionCertificateThumbprint. Please verify that the encryptionCertificateThumbprint setting in install.config contains a valid thumbprint for a certificate in the Local Machine Personal store. Halting installation."
-	throw $_.Exception
+try {
+    $encryptionCert = Get-Certificate $encryptionCertificateThumbprint
+}
+catch {
+    Write-Host "Could not get encryption certificate with thumbprint $encryptionCertificateThumbprint. Please verify that the encryptionCertificateThumbprint setting in install.config contains a valid thumbprint for a certificate in the Local Machine Personal store. Halting installation."
+    throw $_.Exception
 }
 
 
 $userEnteredFabricInstallerSecret = Read-Host  "Enter the Fabric Installer Secret or hit enter to accept the default [$fabricInstallerSecret]"
 Write-Host ""
-if(![string]::IsNullOrEmpty($userEnteredFabricInstallerSecret)){   
-     $fabricInstallerSecret = $userEnteredFabricInstallerSecret
+if (![string]::IsNullOrEmpty($userEnteredFabricInstallerSecret)) {   
+    $fabricInstallerSecret = $userEnteredFabricInstallerSecret
 }
 
-if((Test-Path $zipPackage))
-{
-	$path = [System.IO.Path]::GetDirectoryName($zipPackage)
-	if(!$path)
-	{
-		$zipPackage = [System.IO.Path]::Combine($workingDirectory, $zipPackage)
-		Write-Host "zipPackage: $zipPackage"
-		Write-Host ""
-	}
-}else{
-	Write-Host "Could not find file or directory $zipPackage, please verify that the zipPackage configuration setting in install.config is the path to a valid zip file that exists. Halting installation."
-	exit 1
+if ((Test-Path $zipPackage)) {
+    $path = [System.IO.Path]::GetDirectoryName($zipPackage)
+    if (!$path) {
+        $zipPackage = [System.IO.Path]::Combine($workingDirectory, $zipPackage)
+        Write-Host "zipPackage: $zipPackage"
+        Write-Host ""
+    }
+}
+else {
+    Write-Host "Could not find file or directory $zipPackage, please verify that the zipPackage configuration setting in install.config is the path to a valid zip file that exists. Halting installation."
+    exit 1
 }
 
 
 $userEnteredAuthorizationServiceUrl = Read-Host  "Enter the URL for the Authorization Service or hit enter to accept the default [$authorizationServiceUrl]"
 Write-Host ""
-if(![string]::IsNullOrEmpty($userEnteredAuthorizationServiceUrl)){   
-     $authorizationServiceUrl = $userEnteredAuthorizationServiceUrl
+if (![string]::IsNullOrEmpty($userEnteredAuthorizationServiceUrl)) {   
+    $authorizationServiceUrl = $userEnteredAuthorizationServiceUrl
 }
 
 $userEnteredIdentityServiceUrl = Read-Host  "Enter the URL for the Identity Service or hit enter to accept the default [$identityServerUrl]"
 Write-Host ""
-if(![string]::IsNullOrEmpty($userEnteredIdentityServiceUrl)){   
-     $identityServerUrl = $userEnteredIdentityServiceUrl
+if (![string]::IsNullOrEmpty($userEnteredIdentityServiceUrl)) {   
+    $identityServerUrl = $userEnteredIdentityServiceUrl
 }
 
-if(!($noDiscoveryService)){
+if (!($noDiscoveryService)) {
     $userEnteredDiscoveryServiceUrl = Read-Host "Press Enter to accept the default DiscoveryService URL [$discoveryServiceUrl] or enter a new URL"
     Write-Host ""
-    if(![string]::IsNullOrEmpty($userEnteredDiscoveryServiceUrl)){   
-         $discoveryServiceUrl = $userEnteredDiscoveryServiceUrl
+    if (![string]::IsNullOrEmpty($userEnteredDiscoveryServiceUrl)) {   
+        $discoveryServiceUrl = $userEnteredDiscoveryServiceUrl
     }
 
 }
 
 
-if(![string]::IsNullOrEmpty($storedIisUser)){
+if (![string]::IsNullOrEmpty($storedIisUser)) {
     $userEnteredIisUser = Read-Host "Press Enter to accept the default IIS App Pool User '$($storedIisUser)' or enter a new App Pool User"
-    if([string]::IsNullOrEmpty($userEnteredIisUser)){
+    if ([string]::IsNullOrEmpty($userEnteredIisUser)) {
         $userEnteredIisUser = $storedIisUser
     }
-}else{
+}
+else {
     $userEnteredIisUser = Read-Host "Please enter a user account for the App Pool"
 }
 
-if(![string]::IsNullOrEmpty($userEnteredIisUser)){
+if (![string]::IsNullOrEmpty($userEnteredIisUser)) {
     
     $iisUser = $userEnteredIisUser
     $useSpecificUser = $true
@@ -486,7 +499,7 @@ if(![string]::IsNullOrEmpty($userEnteredIisUser)){
     $credential = New-Object -TypeName "System.Management.Automation.PSCredential" -ArgumentList $iisUser, $userEnteredPassword
     [System.Reflection.Assembly]::LoadWithPartialName("System.DirectoryServices.AccountManagement") | Out-Null
     $ct = [System.DirectoryServices.AccountManagement.ContextType]::Domain
-    $pc = New-Object System.DirectoryServices.AccountManagement.PrincipalContext -ArgumentList $ct,$credential.GetNetworkCredential().Domain
+    $pc = New-Object System.DirectoryServices.AccountManagement.PrincipalContext -ArgumentList $ct, $credential.GetNetworkCredential().Domain
     $isValid = $pc.ValidateCredentials($credential.GetNetworkCredential().UserName, $credential.GetNetworkCredential().Password)
     if(!$isValid){
         Write-Error "Incorrect credentials for $iisUser"
@@ -502,19 +515,19 @@ if(![string]::IsNullOrEmpty($userEnteredIisUser)){
 $userEnteredAppInsightsInstrumentationKey = Read-Host  "Enter Application Insights instrumentation key or hit enter to accept the default [$appInsightsInstrumentationKey]"
 Write-Host ""
 
-if(![string]::IsNullOrEmpty($userEnteredAppInsightsInstrumentationKey)){   
-     $appInsightsInstrumentationKey = $userEnteredAppInsightsInstrumentationKey
+if (![string]::IsNullOrEmpty($userEnteredAppInsightsInstrumentationKey)) {   
+    $appInsightsInstrumentationKey = $userEnteredAppInsightsInstrumentationKey
 }
 
 $userEnteredSqlServerAddress = Read-Host "Press Enter to accept the default Sql Server address '$($sqlServerAddress)' or enter a new Sql Server address" 
 Write-Host ""
 
-if(![string]::IsNullOrEmpty($userEnteredSqlServerAddress)){
+if (![string]::IsNullOrEmpty($userEnteredSqlServerAddress)) {
     $sqlServerAddress = $userEnteredSqlServerAddress
 }
 
 $userEnteredAuthorizationDbName = Read-Host "Press Enter to accept the default Authorization DB Name '$($authorizationDbName)' or enter a new Authorization DB Name"
-if(![string]::IsNullOrEmpty($userEnteredAuthorizationDbName)){
+if (![string]::IsNullOrEmpty($userEnteredAuthorizationDbName)) {
     $authorizationDbName = $userEnteredAuthorizationDbName
 }
 
@@ -524,9 +537,9 @@ Invoke-Sql $authorizationDbConnStr "SELECT TOP 1 ClientId FROM Clients" | Out-Nu
 Write-Success "Identity DB Connection string: $authorizationDbConnStr verified"
 Write-Host ""
 
-if(!($noDiscoveryService)){
+if (!($noDiscoveryService)) {
     $userEnteredMetadataDbName = Read-Host "Press Enter to accept the default Metadata DB Name '$($metadataDbName)' or enter a new Metadata DB Name"
-    if(![string]::IsNullOrEmpty($userEnteredMetadataDbName)){
+    if (![string]::IsNullOrEmpty($userEnteredMetadataDbName)) {
         $metadataDbName = $userEnteredMetadataDbName
     }
 
@@ -539,27 +552,29 @@ if(!($noDiscoveryService)){
 $userEnteredDomain = Read-Host "Press Enter to accept the default domain '$($currentUserDomain)' that the user/group who will administrate dos is a member or enter a new domain" 
 Write-Host ""
 
-if(![string]::IsNullOrEmpty($userEnteredDomain)){
+if (![string]::IsNullOrEmpty($userEnteredDomain)) {
     $currentUserDomain = $userEnteredDomain
 }
 
-if([string]::IsNullOrEmpty($adminAccount)){
+if ([string]::IsNullOrEmpty($adminAccount)) {
     $userEnteredAdminAccount = Read-Host "Please enter the user/group account for dos administration in the format [DOMAIN\user]"
-}else{
+}
+else {
     $userEnteredAdminAccount = Read-Host "Press Enter to accept the default admin account '$($adminAccount)' for the user/group who will administrate dos or enter a new account"
 }
 
 Write-Host ""
 
-if(![string]::IsNullOrEmpty($userEnteredAdminAccount)){
+if (![string]::IsNullOrEmpty($userEnteredAdminAccount)) {
     $adminAccount = $userEnteredAdminAccount
 }
 
 $samAccountName = Get-SamAccountFromAccountName -accountName $adminAccount
 $adminAccountIsUser = $false
-if(Test-IsUser -samAccountName $samAccountName -domain $currentUserDomain){
+if (Test-IsUser -samAccountName $samAccountName -domain $currentUserDomain) {
     $adminAccountIsUser = $true
-}elseif(Test-IsGroup -samAccountName $samAccountName -domain $currentUserDomain){
+}
+elseif (Test-IsGroup -samAccountName $samAccountName -domain $currentUserDomain) {
     $adminAccountIsUser = $false
 }else{
     Write-Error "$samAccountName is not a valid principal in the $currentUserDomain domain. Please enter a valid account. Halting installation."
@@ -572,14 +587,14 @@ Write-Host "Prerequisite checks complete...installing."
 Write-Host ""
 
 
-if(!($noDiscoveryService)){
+if (!($noDiscoveryService)) {
     Write-Host ""
-	Write-Host "Adding Service User to Discovery."
-	Write-Host ""
-	Add-ServiceUserToDiscovery $credential.UserName $metadataConnStr
-	Write-Host ""
-	Write-Host "Registering with Discovery Service."
-	Write-Host ""
+    Write-Host "Adding Service User to Discovery."
+    Write-Host ""
+    Add-ServiceUserToDiscovery $credential.UserName $metadataConnStr
+    Write-Host ""
+    Write-Host "Registering with Discovery Service."
+    Write-Host ""
     Add-DiscoveryRegistration $discoveryServiceUrl "$authorizationServiceUrl/v1" $credential
     Write-Host ""
 }
@@ -608,16 +623,17 @@ $body = @'
 
 Write-Host "Registering Fabric.Authorization API."
 try {
-	$authorizationApiSecret = Add-ApiRegistration -authUrl $identityServerUrl -body $body -accessToken $accessToken
-	Write-Host "Fabric.Authorization apiSecret: $authorizationApiSecret"
-	Write-Host ""
-} catch {
+    $authorizationApiSecret = Add-ApiRegistration -authUrl $identityServerUrl -body $body -accessToken $accessToken
+    Write-Host "Fabric.Authorization apiSecret: $authorizationApiSecret"
+    Write-Host ""
+}
+catch {
     $exception = $_.Exception
-    if($exception -ne $null -and $exception.Response.StatusCode.value__ -eq 409)
-    {
-	    Write-Success "Fabric.Authorization API is already registered."
+    if ($exception -ne $null -and $exception.Response.StatusCode.value__ -eq 409) {
+        Write-Success "Fabric.Authorization API is already registered."
         Write-Host ""
-    }else{
+    }
+    else {
         Write-Error "Could not register Fabric.Authorization with Fabric.Identity, halting installation."
         throw $exception
     }
@@ -636,17 +652,18 @@ $body = @'
 '@
 
 Write-Host "Registering Fabric.Authorization Client."
-try{
-	$authorizationClientSecret = Add-ClientRegistration -authUrl $identityServerUrl -body $body -accessToken $accessToken
-	Write-Host "Fabric.Authorization clientSecret: $authorizationClientSecret"
-	Write-Host ""
-} catch {
+try {
+    $authorizationClientSecret = Add-ClientRegistration -authUrl $identityServerUrl -body $body -accessToken $accessToken
+    Write-Host "Fabric.Authorization clientSecret: $authorizationClientSecret"
+    Write-Host ""
+}
+catch {
     $exception = $_.Exception
-    if($exception -ne $null -and $exception.Response.StatusCode.value__ -eq 409)
-    {
-	    Write-Success "Fabric.Authorization Client is already registered."
+    if ($exception -ne $null -and $exception.Response.StatusCode.value__ -eq 409) {
+        Write-Success "Fabric.Authorization Client is already registered."
         Write-Host ""
-    }else{
+    }
+    else {
         Write-Error "Could not register Fabric.Authorization.Client with Fabric.Identity, halting installation."
         throw $exception
     }
@@ -657,42 +674,43 @@ Write-Host ""
 Write-Host "Loading up environment variables..."
 $environmentVariables = @{"StorageProvider" = "sqlserver"}
 
-if($clientName){
-	$environmentVariables.Add("ClientName", $clientName)
+if ($clientName) {
+    $environmentVariables.Add("ClientName", $clientName)
 }
 
-if ($encryptionCertificateThumbprint){
-	$environmentVariables.Add("EncryptionCertificateSettings__EncryptionCertificateThumbprint", $encryptionCertificateThumbprint)
+if ($encryptionCertificateThumbprint) {
+    $environmentVariables.Add("EncryptionCertificateSettings__EncryptionCertificateThumbprint", $encryptionCertificateThumbprint)
 }
 
-if($appInsightsInstrumentationKey){
-	$environmentVariables.Add("ApplicationInsights__Enabled", "true")
-	$environmentVariables.Add("ApplicationInsights__InstrumentationKey", $appInsightsInstrumentationKey)
+if ($appInsightsInstrumentationKey) {
+    $environmentVariables.Add("ApplicationInsights__Enabled", "true")
+    $environmentVariables.Add("ApplicationInsights__InstrumentationKey", $appInsightsInstrumentationKey)
 }
 
-if($authorizationClientSecret){
-	$encryptedSecret = Get-EncryptedString $encryptionCert $authorizationClientSecret
-	$environmentVariables.Add("IdentityServerConfidentialClientSettings__ClientSecret", $encryptedSecret)
+if ($authorizationClientSecret) {
+    $encryptedSecret = Get-EncryptedString $encryptionCert $authorizationClientSecret
+    $environmentVariables.Add("IdentityServerConfidentialClientSettings__ClientSecret", $encryptedSecret)
 }
 
 
 $environmentVariables.Add("IdentityServerConfidentialClientSettings__Authority", $identityServerUrl)
 
-if($authorizationDbConnStr){
+if ($authorizationDbConnStr) {
     $environmentVariables.Add("ConnectionStrings__AuthorizationDatabase", $authorizationDbConnStr)
 }
 
-if($adminAccount){
+if ($adminAccount) {
     $environmentVariables.Add("AdminAccount__Name", $adminAccount)
 }
 
-if($adminAccountIsUser){
+if ($adminAccountIsUser) {
     $environmentVariables.Add("AdminAccount__Type", "user")
-}else{
+}
+else {
     $environmentVariables.Add("AdminAccount__Type", "group")
 }
 
-if($authorizationApiSecret){
+if ($authorizationApiSecret) {
     $encryptedSecret = Get-EncryptedString $encryptionCert $authorizationApiSecret
     $environmentVariables.Add("IdentityServerApiSettings__ApiSecret", $encryptedSecret)
 }
@@ -706,21 +724,27 @@ Add-AccountToDosAdminRole -accountName $adminAccount -domain $currentUserDomain 
 
 Set-Location $workingDirectory
 
-if($fabricInstallerSecret){ Add-SecureInstallationSetting "common" "fabricInstallerSecret" $fabricInstallerSecret $encryptionCert | Out-Null}
-if($encryptionCertificateThumbprint){ Add-InstallationSetting "common" "encryptionCertificateThumbprint" $encryptionCertificateThumbprint | Out-Null}
-if($encryptionCertificateThumbprint){ Add-InstallationSetting "authorization" "encryptionCertificateThumbprint" $encryptionCertificateThumbprint | Out-Null}
-if($appInsightsInstrumentationKey){ Add-InstallationSetting "authorization" "appInsightsInstrumentationKey" "$appInsightsInstrumentationKey" | Out-Null}
-if($sqlServerAddress){ Add-InstallationSetting "common" "sqlServerAddress" "$sqlServerAddress" | Out-Null}
-if($metadataDbName){ Add-InstallationSetting "common" "metadataDbName" "$metadataDbName" | Out-Null}
-if($identityServerUrl){ Add-InstallationSetting "common" "identityService" "$identityServerUrl" | Out-Null}
-if($discoveryServiceUrl) { Add-InstallationSetting "common" "discoveryService" "$discoveryServiceUrl" | Out-Null}
-if($authorizationServiceUrl) { Add-InstallationSetting "authorization" "authorizationService" "$authorizationServiceUrl" | Out-Null}
-if($authorizationServiceUrl) { Add-InstallationSetting "common" "authorizationService" "$authorizationServiceUrl" | Out-Null}
-if($iisUser) { Add-InstallationSetting "authorization" "iisUser" "$iisUser" | Out-Null}
-if($siteName) {Add-InstallationSetting "authorization" "siteName" "$siteName" | Out-Null}
-if($adminAccount) {Add-InstallationSetting "authorization" "adminAccount" "$adminAccount" | Out-Null}
+if ($fabricInstallerSecret) { Add-SecureInstallationSetting "common" "fabricInstallerSecret" $fabricInstallerSecret $encryptionCert | Out-Null}
+if ($encryptionCertificateThumbprint) { Add-InstallationSetting "common" "encryptionCertificateThumbprint" $encryptionCertificateThumbprint | Out-Null}
+if ($encryptionCertificateThumbprint) { Add-InstallationSetting "authorization" "encryptionCertificateThumbprint" $encryptionCertificateThumbprint | Out-Null}
+if ($appInsightsInstrumentationKey) { Add-InstallationSetting "authorization" "appInsightsInstrumentationKey" "$appInsightsInstrumentationKey" | Out-Null}
+if ($sqlServerAddress) { Add-InstallationSetting "common" "sqlServerAddress" "$sqlServerAddress" | Out-Null}
+if ($metadataDbName) { Add-InstallationSetting "common" "metadataDbName" "$metadataDbName" | Out-Null}
+if ($identityServerUrl) { Add-InstallationSetting "common" "identityService" "$identityServerUrl" | Out-Null}
+if ($discoveryServiceUrl) { Add-InstallationSetting "common" "discoveryService" "$discoveryServiceUrl" | Out-Null}
+if ($authorizationServiceUrl) { Add-InstallationSetting "authorization" "authorizationService" "$authorizationServiceUrl" | Out-Null}
+if ($authorizationServiceUrl) { Add-InstallationSetting "common" "authorizationService" "$authorizationServiceUrl" | Out-Null}
+if ($iisUser) { Add-InstallationSetting "authorization" "iisUser" "$iisUser" | Out-Null}
+if ($siteName) {Add-InstallationSetting "authorization" "siteName" "$siteName" | Out-Null}
+if ($adminAccount) {Add-InstallationSetting "authorization" "adminAccount" "$adminAccount" | Out-Null}
 
 
 Invoke-MonitorShallow "$hostUrl/$appName"
+
+Write-Host "Upgrading all the users/groups with an 'EDW Admin' role to also have the dosadmin Fabric.Auth role"
+$edwAdminUsersAndGroups = Get-EdwAdminUsersAndGroups
+Write-Host "There are $($edwAdminUsersAndGroups.Count) users/groups with this role"
+Write-Host ""
+Add-UsersAndGroupsToDosAdminRole -edwAdminUsersAndGroups $edwAdminUsersAndGroups -domain $currentUserDomain -connString $authorizationDbConnStr -authorizationServiceUrl "$authorizationServiceUrl/v1" -accessToken $accessToken
 
 Read-Host -Prompt "Installation complete, press Enter to exit"

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -276,7 +276,7 @@ function Get-EdwAdminUsersAndGroups($connectionString) {
         $connection.Close()        
 
     }catch [System.Data.SqlClient.SqlException] {
-        Write-Error "An error ocurred while executing the command. Please ensure the connection string is correct and the identity database has been setup. Connection String: $($connectionString). Error $($_.Exception.Message)"  -ErrorAction Stop
+        Write-Error "An error ocurred while executing the command. Please ensure the connection string is correct and the metadata database has been setup. Connection String: $($connectionString). Error $($_.Exception.Message)"  -ErrorAction Stop
     }    
 
     return $usersAndGroups;
@@ -756,9 +756,9 @@ if ($adminAccount) {Add-InstallationSetting "authorization" "adminAccount" "$adm
 Invoke-MonitorShallow "$hostUrl/$appName"
 
 Write-Host "Upgrading all the users/groups with an 'EDW Admin' role to also have the dosadmin Fabric.Auth role"
-$edwAdminUsersAndGroups = Get-EdwAdminUsersAndGroups -connectionString $authorizationDbConnStr
+$edwAdminUsersAndGroups = Get-EdwAdminUsersAndGroups -connectionString $metadataConnStr
 Write-Host "There are $($edwAdminUsersAndGroups.Count) users/groups with this role"
 Write-Host ""
-Add-UsersAndGroupsToDosAdminRole -edwAdminUsersAndGroups $edwAdminUsersAndGroups -domain $currentUserDomain -connString $authorizationDbConnStr -authorizationServiceUrl "$authorizationServiceUrl/v1" -accessToken $accessToken
+Add-UsersAndGroupsToDosAdminRole -edwAdminUsersAndGroups $edwAdminUsersAndGroups -domain $currentUserDomain -connString $metadataConnStr -authorizationServiceUrl "$authorizationServiceUrl/v1" -accessToken $accessToken
 
 Read-Host -Prompt "Installation complete, press Enter to exit"


### PR DESCRIPTION
At the end of the script, I added a query to get the users and groups from EDWAdmin, then iterated over the list and called the already existing `Add-AccountToDosAdminRole` which does all the error checking and adds it to the right table based on whether it is a group or a user.

I also fixed the formatting according to my VS Code preferences... That's a lot of changes and I'm happy to undo them if you prefer. Just let me know. I'll highlight the changes in the PR