### PR TITLE
updated group name input on add custom group page to be a typeahead

### DIFF
--- a/Fabric.Authorization.API/Models/Requests/GroupApiRequest.cs
+++ b/Fabric.Authorization.API/Models/Requests/GroupApiRequest.cs
@@ -10,4 +10,10 @@
         public string DisplayName { get; set; }
         public string Description { get; set; }
     }
+
+    public class GroupSearchApiRequest 
+    {
+        public string Name { get; set; }
+        public string Type { get; set; }
+    }
 }

--- a/Fabric.Authorization.API/Modules/GroupsMetadataModule.cs
+++ b/Fabric.Authorization.API/Modules/GroupsMetadataModule.cs
@@ -226,6 +226,52 @@ namespace Fabric.Authorization.API.Modules
                 }).SecurityRequirement(OAuth2ReadScopeBuilder);
 
             RouteDescriber.DescribeRouteWithParams(
+                "GetGroups",
+                "",
+                "Gets groups by name and an optional type",
+                new List<HttpResponseMetadata>
+                {
+                    new HttpResponseMetadata<GroupRoleApiModel>
+                    {
+                        Code = (int) HttpStatusCode.OK,
+                        Message = "OK"
+                    },
+                    new HttpResponseMetadata
+                    {
+                        Code = (int) HttpStatusCode.Forbidden,
+                        Message = "Client does not have access"
+                    },
+                    new HttpResponseMetadata<Error>
+                    {
+                        Code = (int) HttpStatusCode.BadRequest,
+                        Message = "No name parameter was provided or an invalid type parameter was provided"
+                    }
+                },
+                new[]
+                {
+                    new Parameter()
+                    {
+                        Name = "name",
+                        Description = "the group name",
+                        Required = true,
+                        Type = "string",
+                        In = ParameterIn.Query
+                    },
+                    new Parameter()
+                    {
+                        Name = "type",
+                        Description = "the type of group, either 'custom' or 'directory'",
+                        Required = false,
+                        Type = "string",
+                        In = ParameterIn.Query
+                    }
+                },
+                new[]
+                {
+                    _groupsTag
+                }).SecurityRequirement(OAuth2ReadScopeBuilder);
+
+            RouteDescriber.DescribeRouteWithParams(
                 "DeleteGroup",
                 "",
                 "Deletes a group",

--- a/Fabric.Authorization.API/Modules/GroupsModule.cs
+++ b/Fabric.Authorization.API/Modules/GroupsModule.cs
@@ -123,6 +123,10 @@ namespace Fabric.Authorization.API.Modules
             {
                 this.RequiresClaims(AuthorizationReadClaim);
                 var requestParams = this.Bind<GroupSearchApiRequest>();
+                if (string.IsNullOrEmpty(requestParams.Name))
+                {
+                   return CreateFailureResponse("Name is required", HttpStatusCode.BadRequest);
+                }
                 IEnumerable<Group> groups = await _groupService.GetGroups(requestParams.Name, requestParams.Type);
                 return groups.OrderBy(g => g.Name).Select(g => g.ToGroupRoleApiModel());
             }

--- a/Fabric.Authorization.API/Modules/GroupsModule.cs
+++ b/Fabric.Authorization.API/Modules/GroupsModule.cs
@@ -124,7 +124,7 @@ namespace Fabric.Authorization.API.Modules
                 this.RequiresClaims(AuthorizationReadClaim);
                 var requestParams = this.Bind<GroupSearchApiRequest>();
                 IEnumerable<Group> groups = await _groupService.GetGroups(requestParams.Name, requestParams.Type);
-                return groups.Select(g => g.ToGroupRoleApiModel());
+                return groups.OrderBy(g => g.Name).Select(g => g.ToGroupRoleApiModel());
             }
             catch (NotFoundException<Group> ex)
             {

--- a/Fabric.Authorization.API/Modules/GroupsModule.cs
+++ b/Fabric.Authorization.API/Modules/GroupsModule.cs
@@ -126,7 +126,7 @@ namespace Fabric.Authorization.API.Modules
                 IEnumerable<Group> groups = await _groupService.GetGroups(requestParams.Name, requestParams.Type);
                 return groups.OrderBy(g => g.Name).Select(g => g.ToGroupRoleApiModel());
             }
-            catch (NotFoundException<Group> ex)
+            catch (BadRequestException<Group> ex)
             {
                 return CreateFailureResponse(ex.Message, HttpStatusCode.BadRequest);
             }

--- a/Fabric.Authorization.AccessControl/src/app/models/group.model.ts
+++ b/Fabric.Authorization.AccessControl/src/app/models/group.model.ts
@@ -9,4 +9,7 @@ export interface IGroup {
   groupSource: string;
   displayName?: string;
   description?: string;
+
+   // Custom Property
+   selected?: boolean;
 }

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/access-control.scss
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/access-control.scss
@@ -36,10 +36,10 @@ table.hc-table {
 }
 
 .scroll-table{
-$scrollbar-width: 0.9em;
-display: flex;
-flex-flow: column;
-max-height: 180px;
+    $scrollbar-width: 0.9em;
+    display: flex;
+    flex-flow: column;
+    max-height: 180px;
 
 thead,
 tbody tr {

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
@@ -8,6 +8,7 @@
         <div class="form-errors" *ngIf="groupNameinvalid" [innerText]="groupNameError"></div>
     </div>
     <div>
+        <div *ngIf="customGroups.length > 0">Select an existing group:</div>
         <ul *ngFor="let group of customGroups">
             <li>
                 <hc-checkbox [id]="group.id" [(ngModel)]="group.selected" (click)="customGroupSelected(group)">{{group.groupName}}</hc-checkbox>

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
@@ -4,7 +4,15 @@
     </h3>
     <div class="input-combo">
         <input hc-input class="hc-input" required [(ngModel)]="groupName" [readOnly]="editMode" [highlight]="groupNameinvalid" (keyup)="groupNameSubject.next($event.target.value)">
+        <i [class]="searchingGroup ? 'btn-icon fa fa-spinner fa-pulse fa-fw' : 'btn-icon fa fa-search'"></i>
         <div class="form-errors" *ngIf="groupNameinvalid" [innerText]="groupNameError"></div>
+    </div>
+    <div>
+        <ul *ngFor="let group of customGroups">
+            <li>
+                <hc-checkbox [id]="group.id" [(ngModel)]="group.selected" (click)="customGroupSelected(group)">{{group.groupName}}</hc-checkbox>
+            </li>
+        </ul>
     </div>
     <h3 class="h3">
         <span>Associated Users</span>

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
@@ -3,14 +3,14 @@
         <span>Custom Group Name</span>
     </h3>
     <div class="input-combo">
-        <input hc-input class="hc-input" required [(ngModel)]="groupName" [readOnly]="editMode" [highlight]="groupNameinvalid" (keyup)="groupNameSubject.next($event.target.value)">
+        <input hc-input class="hc-input" required [(ngModel)]="groupName" [readOnly]="editMode" [highlight]="groupNameinvalid" (keyup)="groupNameSubject.next($event.target.value)" placeholder="enter group name">
         <i [class]="searchingGroup ? 'btn-icon fa fa-spinner fa-pulse fa-fw' : 'btn-icon fa fa-search'"></i>
         <div class="form-errors" *ngIf="groupNameinvalid" [innerText]="groupNameError"></div>
     </div>
-    <div>
-        <div *ngIf="customGroups.length > 0">Select an existing group:</div>
-        <ul *ngFor="let group of customGroups">
-            <li>
+    <div class="scroll-list">
+        <div *ngIf="customGroups.length > 0"><span>Select an existing group:</span></div>
+        <ul>
+            <li *ngFor="let group of customGroups">
                 <hc-checkbox [id]="group.id" [(ngModel)]="group.selected" (click)="customGroupSelected(group)">{{group.groupName}}</hc-checkbox>
             </li>
         </ul>

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.scss
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.scss
@@ -56,5 +56,27 @@
     .top {
         width: 100%;
         padding: 0 0 15px 0;
+    }    
+}
+
+.scroll-list{
+    $scrollbar-width: 0.9em;
+    display: flex;
+    flex-flow: column;
+    max-height: 180px;
+
+    ul{
+        max-height: 180px;
+        overflow: auto;
+    }
+
+    li{
+        padding-bottom: .15em; 
+    }
+
+    span{
+        padding: .25em 0 .25em 0;
+        display: block;        
+        font-weight: 600;
     }
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.ts
@@ -182,4 +182,21 @@ export class FabricAuthGroupService extends FabricBaseService {
   ): string {
     return encodeURI(tokenizedUrl.replace('{groupName}', groupName));
   }
+
+  public search(groupName: Observable<string>): Observable<IGroup[]> {
+    return groupName.debounceTime(250)
+      .distinctUntilChanged()
+      .filter((term: string) =>  term && term.length > 2)
+      .switchMap((term) => {
+        let params = new HttpParams()
+          .set('name', term);
+
+        params = params.set('type', 'custom');
+
+        return this.httpClient.get<IGroup[]>(
+          FabricAuthGroupService.baseGroupApiUrl,
+          { params }
+        );
+      });
+  }
 }

--- a/Fabric.Authorization.Domain/Services/GroupService.cs
+++ b/Fabric.Authorization.Domain/Services/GroupService.cs
@@ -205,6 +205,15 @@ namespace Fabric.Authorization.Domain.Services
 
         public async Task<IEnumerable<Group>> GetGroups(string name, string type)
         {
+            if (!string.IsNullOrEmpty(type))
+            {
+                type = type.ToLower();
+                if (!type.Equals("custom") && !type.Equals("directory"))
+                {
+                    throw new BadRequestException<Group>("Invalid type provided. If provided valid values are custom or directory");
+                }
+            }
+
             var groups = await _groupStore.GetGroups(name, type);
             return groups;
         }

--- a/Fabric.Authorization.Domain/Services/GroupService.cs
+++ b/Fabric.Authorization.Domain/Services/GroupService.cs
@@ -205,8 +205,7 @@ namespace Fabric.Authorization.Domain.Services
 
         public async Task<IEnumerable<Group>> GetGroups(string name, string type)
         {
-            var groups = await _groupStore.GetGroups(name);
-
+            var groups = await _groupStore.GetGroups(name, type);
             return groups;
         }
     }

--- a/Fabric.Authorization.Domain/Services/GroupService.cs
+++ b/Fabric.Authorization.Domain/Services/GroupService.cs
@@ -202,5 +202,12 @@ namespace Fabric.Authorization.Domain.Services
 
             return await _groupStore.DeleteUserFromGroup(group, user);
         }
+
+        public async Task<IEnumerable<Group>> GetGroups(string name, string type)
+        {
+            var groups = await _groupStore.GetGroups(name);
+
+            return groups;
+        }
     }
 }

--- a/Fabric.Authorization.Domain/Stores/IGroupStore.cs
+++ b/Fabric.Authorization.Domain/Stores/IGroupStore.cs
@@ -12,6 +12,6 @@ namespace Fabric.Authorization.Domain.Stores
         Task<Group> AddUserToGroup(Group group, User user);
         Task<Group> AddUsersToGroup(Group group, IEnumerable<User> usersToAdd);
         Task<Group> DeleteUserFromGroup(Group group, User user);
-        Task<IEnumerable<Group>> GetGroups(string name);
+        Task<IEnumerable<Group>> GetGroups(string name, string type);
     }
 }

--- a/Fabric.Authorization.Domain/Stores/IGroupStore.cs
+++ b/Fabric.Authorization.Domain/Stores/IGroupStore.cs
@@ -12,5 +12,6 @@ namespace Fabric.Authorization.Domain.Stores
         Task<Group> AddUserToGroup(Group group, User user);
         Task<Group> AddUsersToGroup(Group group, IEnumerable<User> usersToAdd);
         Task<Group> DeleteUserFromGroup(Group group, User user);
+        Task<IEnumerable<Group>> GetGroups(string name);
     }
 }

--- a/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/GroupsTests.cs
@@ -1349,6 +1349,20 @@ namespace Fabric.Authorization.IntegrationTests.Modules
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
 
+        [Fact]
+        [IntegrationTestsFixture.DisplayTestMethodName]
+        public async Task SearchGroups_NoName_BadRequest_Async()
+        {
+            var response = await Browser.Get($"/groups", with =>
+            {
+                with.HttpRequest();                
+                with.Query("type", "foo");
+                with.Header("Accept", "application/json");
+            });
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
+
         // ReSharper disable once UnusedParameter.Local
         private async Task VerifyPermissionAsync(string groupName, string roleName, string permissionName, bool exists)
         {

--- a/Fabric.Authorization.Persistence.CouchDb/Stores/CouchDBGroupStore.cs
+++ b/Fabric.Authorization.Persistence.CouchDb/Stores/CouchDBGroupStore.cs
@@ -137,7 +137,7 @@ namespace Fabric.Authorization.Persistence.CouchDb.Stores
             return group;
         }
 
-        public Task<IEnumerable<Group>> GetGroups(string name)
+        public Task<IEnumerable<Group>> GetGroups(string name, string type)
         {
             throw new NotImplementedException();
         }

--- a/Fabric.Authorization.Persistence.CouchDb/Stores/CouchDBGroupStore.cs
+++ b/Fabric.Authorization.Persistence.CouchDb/Stores/CouchDBGroupStore.cs
@@ -137,6 +137,11 @@ namespace Fabric.Authorization.Persistence.CouchDb.Stores
             return group;
         }
 
+        public Task<IEnumerable<Group>> GetGroups(string name)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<Group> AddRolesToGroup(Group @group, IEnumerable<Role> rolesToAdd)
         {
             throw new NotImplementedException();

--- a/Fabric.Authorization.Persistence.InMemory/Stores/InMemoryGroupStore.cs
+++ b/Fabric.Authorization.Persistence.InMemory/Stores/InMemoryGroupStore.cs
@@ -119,7 +119,7 @@ namespace Fabric.Authorization.Persistence.InMemory.Stores
             return group;
         }
 
-        public Task<IEnumerable<Group>> GetGroups(string name)
+        public Task<IEnumerable<Group>> GetGroups(string name, string type)
         {
             throw new NotImplementedException();
         }

--- a/Fabric.Authorization.Persistence.InMemory/Stores/InMemoryGroupStore.cs
+++ b/Fabric.Authorization.Persistence.InMemory/Stores/InMemoryGroupStore.cs
@@ -119,6 +119,11 @@ namespace Fabric.Authorization.Persistence.InMemory.Stores
             return group;
         }
 
+        public Task<IEnumerable<Group>> GetGroups(string name)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<Group> AddRolesToGroup(Group @group, IEnumerable<Role> rolesToAdd)
         {
             throw new NotImplementedException();

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
@@ -291,5 +291,28 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
 
             return group;
         }
+
+        public async Task<IEnumerable<Group>> GetGroups(string name)
+        {
+            var groupEntities = await AuthorizationDbContext.Groups
+                .Include(g => g.GroupRoles)
+                .ThenInclude(gr => gr.Role)
+                .ThenInclude(r => r.RolePermissions)
+                .ThenInclude(rp => rp.Permission)
+                .ThenInclude(p => p.SecurableItem)
+                .Include(g => g.GroupUsers)
+                .ThenInclude(gu => gu.User)
+                .ThenInclude(u => u.UserPermissions)
+                .ThenInclude(up => up.Permission)
+                .Include(g => g.GroupRoles)
+                .ThenInclude(gr => gr.Role)
+                .ThenInclude(r => r.SecurableItem)
+                .AsNoTracking()
+                .Where(g => g.Name.Contains(name)
+                            && !g.IsDeleted)
+                .ToArrayAsync();
+
+            return groupEntities.Select(g => g.ToModel());
+        }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
@@ -320,7 +320,7 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
 
         private Expression<Func<EntityModels.Group, bool>> GetGroupSourceFilter(string source)
         {
-            switch (source)
+            switch (source?.ToLower())
             {
                 case "custom":
                     return group => group.Source == "custom";


### PR DESCRIPTION
when a user starts to enter a custom group a search will be done against existing custom groups and those with a name that starts with what the user enters will be returned. the user can then select an existing group or enter a new one. 