### PR TITLE
made logging of DB queries configurable

### DIFF
--- a/Fabric.Authorization.API/Configuration/AppConfiguration.cs
+++ b/Fabric.Authorization.API/Configuration/AppConfiguration.cs
@@ -17,5 +17,6 @@ namespace Fabric.Authorization.API.Configuration
         public EncryptionCertificateSettings EncryptionCertificateSettings { get; set; }
         public DefaultPropertySettings DefaultPropertySettings{ get; set; }
         public ConnectionStrings ConnectionStrings { get; set; }
+        public EntityFrameworkSettings EntityFrameworkSettings { get; set; }
     }
 }

--- a/Fabric.Authorization.API/Configuration/IAppConfiguration.cs
+++ b/Fabric.Authorization.API/Configuration/IAppConfiguration.cs
@@ -17,5 +17,6 @@ namespace Fabric.Authorization.API.Configuration
         EncryptionCertificateSettings EncryptionCertificateSettings { get; }
         DefaultPropertySettings DefaultPropertySettings{ get; }
         ConnectionStrings ConnectionStrings { get; }
+        EntityFrameworkSettings EntityFrameworkSettings { get; set; }
     }
 }

--- a/Fabric.Authorization.API/Logging/LogFactory.cs
+++ b/Fabric.Authorization.API/Logging/LogFactory.cs
@@ -3,6 +3,7 @@ using Fabric.Authorization.API.Configuration;
 using Fabric.Authorization.API.Constants;
 using Serilog;
 using Serilog.Core;
+using Serilog.Events;
 using Serilog.Filters;
 using Serilog.Sinks.MSSqlServer;
 
@@ -46,13 +47,13 @@ namespace Fabric.Authorization.API.Logging
 
         private static LoggerConfiguration CreateLoggerConfiguration(LoggingLevelSwitch levelSwitch, IAppConfiguration appConfiguration)
         {
-            var isDbCommand = Matching.FromSource("Microsoft.EntityFrameworkCore");
+            Func<LogEvent, bool> isEfCoreLogEventFunc = Matching.FromSource("Microsoft.EntityFrameworkCore");
             var dbMinimumLogLevel = appConfiguration.EntityFrameworkSettings?.MinimumLogLevel ?? levelSwitch.MinimumLevel;
 
             return new LoggerConfiguration()
                 .MinimumLevel.ControlledBy(levelSwitch)
                 .Enrich.FromLogContext()
-                .Filter.ByExcluding(logEvent => logEvent.Level < dbMinimumLogLevel && isDbCommand.Invoke(logEvent))
+                .Filter.ByExcluding(logEvent => logEvent.Level < dbMinimumLogLevel && isEfCoreLogEventFunc.Invoke(logEvent))
                 .WriteTo.ColoredConsole();
         }
     }

--- a/Fabric.Authorization.API/Modules/FabricModule.cs
+++ b/Fabric.Authorization.API/Modules/FabricModule.cs
@@ -12,7 +12,6 @@ using Fabric.Authorization.API.Services;
 using Fabric.Authorization.Domain.Exceptions;
 using Fabric.Authorization.Domain.Models;
 using Fabric.Authorization.Domain.Services;
-using Fabric.Authorization.Domain.Validators;
 using FluentValidation;
 using Nancy;
 using Nancy.Extensions;

--- a/Fabric.Authorization.API/Startup.cs
+++ b/Fabric.Authorization.API/Startup.cs
@@ -37,7 +37,7 @@ namespace Fabric.Authorization.API
 
             _levelSwitch = new LoggingLevelSwitch();
             _idServerSettings = _appConfig.IdentityServerConfidentialClientSettings;
-            _logger = Logging.LogFactory.CreateTraceLogger(_levelSwitch, _appConfig.ApplicationInsights);
+            _logger = Logging.LogFactory.CreateTraceLogger(_levelSwitch, _appConfig);
 
         }
         // This method gets called by the runtime. Use this method to add services to the container.

--- a/Fabric.Authorization.API/appsettings.json
+++ b/Fabric.Authorization.API/appsettings.json
@@ -40,5 +40,8 @@
   },
   "ConnectionStrings": {
     "AuthorizationDatabase": "Server=localhost;Database=Authorization;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "EntityFrameworkSettings": {
+    "MinimumLogLevel": "Warning"
   }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Configuration/EntityFrameworkSettings.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Configuration/EntityFrameworkSettings.cs
@@ -1,0 +1,9 @@
+﻿using Serilog.Events;
+
+namespace Fabric.Authorization.Persistence.SqlServer.Configuration
+{
+    public class EntityFrameworkSettings
+    {
+        public LogEventLevel MinimumLogLevel { get; set; }
+    }
+}

--- a/Fabric.Authorization.Persistence.SqlServer/Fabric.Authorization.Persistence.SqlServer.csproj
+++ b/Fabric.Authorization.Persistence.SqlServer/Fabric.Authorization.Persistence.SqlServer.csproj
@@ -26,6 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Folder Include="Configuration\" />
     <Folder Include="DependencyInjection\" />
     <Folder Include="Mappers\" />
   </ItemGroup>

--- a/Fabric.Authorization.Persistence.SqlServer/Fabric.Authorization.Persistence.SqlServer.csproj
+++ b/Fabric.Authorization.Persistence.SqlServer/Fabric.Authorization.Persistence.SqlServer.csproj
@@ -26,7 +26,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Configuration\" />
     <Folder Include="DependencyInjection\" />
     <Folder Include="Mappers\" />
   </ItemGroup>


### PR DESCRIPTION
I ended up making this configurable based on a minimum `LogEventLevel` so that we still get DB exceptions logged.