### PR TITLE
Trim ending discovery slash

### DIFF
--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -499,6 +499,7 @@ if (!($noDiscoveryService)) {
         $discoveryServiceUrl = $userEnteredDiscoveryServiceUrl
     }
 
+    $discoveryServiceUrl = $discoveryServiceUrl.TrimEnd('/')
 }
 
 


### PR DESCRIPTION
Trim ending slash after prompting user input for discovery url so either user input or already existing discovery url has it's ending slash removed