### PR TITLE
Added option -i to switch between local code and running dockerhub image

### DIFF
--- a/Fabric.Authorization.API/scripts/run-client-functional-tests.sh
+++ b/Fabric.Authorization.API/scripts/run-client-functional-tests.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+IMAGE="0"
+
+# call script with -i to use the docker hub image
+for i in "$@"
+do
+case $i in
+    -i)
+    IMAGE="1";;
+	*)
+	echo "$0"
+   	echo "usage: $0 [-i] [--help] [-h]"
+   	echo ""
+   	echo "This script gets Identity and Authorization docker images to run tests against them.  By default the script will build the image, but if you use -i, this will pull down the image for Authorization."
+   	echo ""
+   	echo "Options:"
+   	echo "-i                  Use DockerHub Image"
+   	echo "--help, -h          Display this help page"
+   	exit 0
+    ;;
+esac
+done
+
 docker stop authz-client-functional-authorization
 docker rm authz-client-functional-authorization
 docker stop authz-client-functional-identity
@@ -23,7 +45,7 @@ echo "started identity"
 sleep 3
 
 curl -sSL https://raw.githubusercontent.com/HealthCatalyst/Fabric.Identity/master/Fabric.Identity.API/scripts/setup-samples.sh > identity-setup-samples.sh
-output=$(. identity-setup-samples.sh)
+output=$(. identity-setup-samples.sh "http://localhost:5001")
 installerSecret=$(echo $output | grep -oP '(?<="installerSecret":")[^"]*')
 authClientSecret=$(echo $output | grep -oP '(?<="authClientSecret":")[^"]*')
 
@@ -31,13 +53,25 @@ export FABRIC_INSTALLER_SECRET=$installerSecret
 echo $installerSecret
 echo $authClientSecret
 
+if [ "$IMAGE" -eq "1" ]; then
+	echo "Using docker image"
+	IMAGE_NAME="healthcatalyst/fabric.authorization"
+else
+	echo "Using local code"
+	IMAGE_NAME="authorization.functional.api"
+	cd ..
+	dotnet publish -o obj/Docker/publish
+	docker build -t $IMAGE_NAME .		
+fi
+
 docker run -d --name authz-client-functional-authorization \
 	-p 5004:5004 \
 	-e STORAGEPROVIDER=InMemory \
 	-e IDENTITYSERVERCONFIDENTIALCLIENTSETTINGS__AUTHORITY=http://authz-client-functional-identity:5001/ \
 	-e IDENTITYSERVERCONFIDENTIALCLIENTSETTINGS__CLIENTSECRET=$authClientSecret \
 	--network="authz-client-functional-tests" \
-	healthcatalyst/fabric.authorization
+	$IMAGE_NAME
+
 echo "started authorization"
 sleep 5 
 


### PR DESCRIPTION
Added option -i to switch between local code and running dockerhub image

- Added a loop to parse the args for the "-i"
- Added a switch to name whether the disk comes from docker hub or local, and if it is local then build the image
-identity-setup-samples.sh needed an arg because it was using the parent script's args and that was causing issues.