### PR TITLE
Added nuget target to include project references properly

### DIFF
--- a/Fabric.Authorization.Client.UnitTests/Fabric.Authorization.Client.UnitTests.csproj
+++ b/Fabric.Authorization.Client.UnitTests/Fabric.Authorization.Client.UnitTests.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Fabric.Authorization.Client\Fabric.Authorization.Client.csproj" />
+    <ProjectReference Include="..\Fabric.Authorization.Models\Fabric.Authorization.Models.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Fabric.Authorization.Client/Fabric.Authorization.Client.csproj
+++ b/Fabric.Authorization.Client/Fabric.Authorization.Client.csproj
@@ -2,6 +2,21 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
+    <Authors>Fabric.Authorization.Client</Authors>
+    <Company>Health Catalyst</Company>
+    <Version>1.0.0.0</Version>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Description />
+    <Copyright>Copyright © 2018</Copyright>
+    <PackageLicenseUrl />
+    <PackageProjectUrl />
+    <PackageIconUrl />
+    <RepositoryUrl>https://github.com/HealthCatalyst/Fabric.Authorization</RepositoryUrl>
+    <RepositoryType>github</RepositoryType>
+    <PackageTags>Fabric Authorization Client</PackageTags>
+    <PackageReleaseNotes />
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +24,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Fabric.Authorization.Models\Fabric.Authorization.Models.csproj" />
+    <ProjectReference Include="..\Fabric.Authorization.Models\Fabric.Authorization.Models.csproj" PrivateAssets="all" />
   </ItemGroup>
+
+  <!--
+  This code below is to run and take every project reference that has a "PrivateAssets=all" and
+  copies it into the nuget project.  If you do not want this to happen (like a nuget reference), 
+  then dont add the Private Assets attribute.
+  
+  Also, this only works for one level.  If there are multiple project reference levels, then each
+  library must be referenced to the main project directly.
+  -->
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')-&gt;WithMetadataValue('PrivateAssets', 'All'))" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/Fabric.Authorization.Models/Fabric.Authorization.Models.csproj
+++ b/Fabric.Authorization.Models/Fabric.Authorization.Models.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard1.6</TargetFramework>
+    <Version>1.0.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added code that will package project references using a build target.  The target works by looking for PrivateAssets="all", which indicates it is part of this package (Not something that is public like in a nuget repo.).  If this is not included, then the nuget pack will assume the reference is in nuget repo and it will not pull in those resources.