### PR TITLE
Corrected forward slash issue.

### DIFF
--- a/Catalyst.Fabric.Authorization.Client.UnitTests/AuthorizationClientTests.cs
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/AuthorizationClientTests.cs
@@ -18,6 +18,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests
         public AuthorizationClientTests()
         {
             _client = new HttpClient();
+            _client.BaseAddress = new Uri("https://example.com/authorization2/");
             _subject = new AuthorizationClient(_client);
             _userPermission = new UserPermissionsApiModel
             {
@@ -35,6 +36,36 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests
                     "view"
                 }
             };
+        }
+
+        [Fact]
+        public void Constructor_HttpClientBase_AppendsForwardSlash()
+        {
+            // Arrange
+            var url = "http://example.com/authorization2";
+            var newHttpClient = new HttpClient();
+            newHttpClient.BaseAddress = new Uri(url);
+
+            // Act
+            var newSubject = new AuthorizationClient(newHttpClient);
+
+            // Assert
+            Assert.Equal($"{url}/", newHttpClient.BaseAddress.OriginalString);
+        }
+
+        [Fact]
+        public void Constructor_HttpClientBase_DoesNotAppendsForwardSlash()
+        {
+            // Arrange
+            var url = "http://example.com/authorization2/";
+            var newHttpClient = new HttpClient();
+            newHttpClient.BaseAddress = new Uri(url);
+
+            // Act
+            var newSubject = new AuthorizationClient(newHttpClient);
+
+            // Assert
+            Assert.Equal(url, newHttpClient.BaseAddress.OriginalString);
         }
 
         [Fact]

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/ClientRouteTests.cs
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/ClientRouteTests.cs
@@ -9,14 +9,14 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         public void ClientRouteBuilder_NoClientId_Success()
         {
             var route = new ClientRouteBuilder().Route;
-            Assert.Equal($"/{RouteConstants.ClientCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.ClientCollectionRoute}", route);
         }
 
         [Fact]
         public void ClientRouteBuilder_WithClientId_Success()
         {
             var route = new ClientRouteBuilder().ClientId("client_id").Route;
-            Assert.Equal($"/{RouteConstants.ClientCollectionRoute}/client_id", route);
+            Assert.Equal($"{RouteConstants.ClientCollectionRoute}/client_id", route);
         }
     }
 }

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/GroupRouteTests.cs
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/GroupRouteTests.cs
@@ -9,35 +9,35 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         public void GroupRouteBuilder_NoParameters_Success()
         {
             var route = new GroupRouteBuilder().Route;
-            Assert.Equal($"/{RouteConstants.GroupCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.GroupCollectionRoute}", route);
         }
 
         [Fact]
         public void GroupRouteBuilder_WithGroupName_Success()
         {
             var route = new GroupRouteBuilder().Name("groupName").Route;
-            Assert.Equal($"/{RouteConstants.GroupCollectionRoute}/groupName", route);
+            Assert.Equal($"{RouteConstants.GroupCollectionRoute}/groupName", route);
         }
 
         [Fact]
         public void GroupRouteBuilderRolesRoute_WithGroupNameAndGrainAndSecurableItem_Success()
         {
             var route = new GroupRouteBuilder().Name("groupName").Grain("app").SecurableItem("patientsafety").GroupRolesRoute;
-            Assert.Equal($"/{RouteConstants.GroupCollectionRoute}/groupName/app/patientsafety/{RouteConstants.RoleCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.GroupCollectionRoute}/groupName/app/patientsafety/{RouteConstants.RoleCollectionRoute}", route);
         }
 
         [Fact]
         public void GroupRouteBuilderRolesRoute_WithGroupNameAndSecurableItemAndNoGrain_Success()
         {
             var route = new GroupRouteBuilder().Name("groupName").SecurableItem("patientsafety").GroupRolesRoute;
-            Assert.Equal($"/{RouteConstants.GroupCollectionRoute}/groupName/{RouteConstants.RoleCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.GroupCollectionRoute}/groupName/{RouteConstants.RoleCollectionRoute}", route);
         }
 
         [Fact]
         public void GroupRouteBuilderUsersRoute_WithGroupName_Success()
         {
             var route = new GroupRouteBuilder().Name("groupName").GroupUsersRoute;
-            Assert.Equal($"/{RouteConstants.GroupCollectionRoute}/groupName/{RouteConstants.UserCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.GroupCollectionRoute}/groupName/{RouteConstants.UserCollectionRoute}", route);
         }
     }
 }

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/MemberSearchRouteTests.cs
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/MemberSearchRouteTests.cs
@@ -9,7 +9,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         public void MemberSearchBuilderRoute_NoParameters_Success()
         {
             var route = new MemberSearchRouteBuilder().Route;
-            Assert.Equal($"/{RouteConstants.MemberCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.MemberCollectionRoute}", route);
         }
     }
 }

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/PermissionRouteTests.cs
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/PermissionRouteTests.cs
@@ -10,7 +10,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         public void PermissionRouteBuilder_NoParameters_Success()
         {
             var route = new PermissionRouteBuilder().Route;
-            Assert.Equal($"/{RouteConstants.PermissionCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.PermissionCollectionRoute}", route);
         }
 
         [Fact]
@@ -18,21 +18,21 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         {
             var id = Guid.NewGuid();
             var route = new PermissionRouteBuilder().PermissionId(id.ToString()).Route;
-            Assert.Equal($"/{RouteConstants.PermissionCollectionRoute}/{id}", route);
+            Assert.Equal($"{RouteConstants.PermissionCollectionRoute}/{id}", route);
         }
 
         [Fact]
         public void PermissionRouteBuilder_WithGrainAndSecurableItem_Success()
         {
             var route = new PermissionRouteBuilder().Grain("app").SecurableItem("patientsafety").Route;
-            Assert.Equal($"/{RouteConstants.PermissionCollectionRoute}/app/patientsafety", route);
+            Assert.Equal($"{RouteConstants.PermissionCollectionRoute}/app/patientsafety", route);
         }
 
         [Fact]
         public void PermissionRouteBuilder_WithGrainAndSecurableItemAndName_Success()
         {
             var route = new PermissionRouteBuilder().Grain("app").SecurableItem("patientsafety").Name("permissionName").Route;
-            Assert.Equal($"/{RouteConstants.PermissionCollectionRoute}/app/patientsafety/permissionName", route);
+            Assert.Equal($"{RouteConstants.PermissionCollectionRoute}/app/patientsafety/permissionName", route);
         }
     }
 }

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/RoleRouteTests.cs
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/RoleRouteTests.cs
@@ -10,7 +10,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         public void RoleRouteBuilder_NoParameters_Success()
         {
             var route = new RoleRouteBuilder().Route;
-            Assert.Equal($"/{RouteConstants.RoleCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.RoleCollectionRoute}", route);
         }
 
         [Fact]
@@ -18,21 +18,21 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         {
             var id = Guid.NewGuid();
             var route = new RoleRouteBuilder().RoleId(id.ToString()).Route;
-            Assert.Equal($"/{RouteConstants.RoleCollectionRoute}/{id}", route);
+            Assert.Equal($"{RouteConstants.RoleCollectionRoute}/{id}", route);
         }
 
         [Fact]
         public void RoleRouteBuilder_WithGrainAndSecurableItem_Success()
         {
             var route = new RoleRouteBuilder().Grain("app").SecurableItem("patientsafety").Route;
-            Assert.Equal($"/{RouteConstants.RoleCollectionRoute}/app/patientsafety", route);
+            Assert.Equal($"{RouteConstants.RoleCollectionRoute}/app/patientsafety", route);
         }
 
         [Fact]
         public void RoleRouteBuilder_WithGrainAndSecurableItemAndName_Success()
         {
             var route = new RoleRouteBuilder().Grain("app").SecurableItem("patientsafety").Name("roleName").Route;
-            Assert.Equal($"/{RouteConstants.RoleCollectionRoute}/app/patientsafety/roleName", route);
+            Assert.Equal($"{RouteConstants.RoleCollectionRoute}/app/patientsafety/roleName", route);
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         {
             var id = Guid.NewGuid();
             var route = new RoleRouteBuilder().RoleId(id.ToString()).RolePermissionsRoute;
-            Assert.Equal($"/{RouteConstants.RoleCollectionRoute}/{id}/{RouteConstants.PermissionCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.RoleCollectionRoute}/{id}/{RouteConstants.PermissionCollectionRoute}", route);
         }
     }
 }

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/UserRouteTests.cs
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Routes/UserRouteTests.cs
@@ -9,49 +9,49 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         public void UserRouteBuilder_NoParameters_Success()
         {
             var route = new UserRouteBuilder().Route;
-            Assert.Equal($"/{RouteConstants.UserRoute}", route);
+            Assert.Equal($"{RouteConstants.UserRoute}", route);
         }
 
         [Fact]
         public void UserRouteBuilder_WithUserId_Success()
         {
             var route = new UserRouteBuilder().IdentityProvider("windows").SubjectId("first.last").Route;
-            Assert.Equal($"/{RouteConstants.UserRoute}/windows/first.last", route);
+            Assert.Equal($"{RouteConstants.UserRoute}/windows/first.last", route);
         }
 
         [Fact]
         public void UserRouteBuilderPermissionsRoute_NoParameters_Success()
         {
             var route = new UserRouteBuilder().UserPermissionsRoute;
-            Assert.Equal($"/{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}", route);
         }
 
         [Fact]
         public void UserRouteBuilderPermissionsRoute_WithUserId_Success()
         {
             var route = new UserRouteBuilder().IdentityProvider("windows").SubjectId("first.last").UserPermissionsRoute;
-            Assert.Equal($"/{RouteConstants.UserRoute}/windows/first.last/{RouteConstants.PermissionCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.UserRoute}/windows/first.last/{RouteConstants.PermissionCollectionRoute}", route);
         }
 
         [Fact]
         public void UserRouteBuilderGroupsRoute_WithUserId_Success()
         {
             var route = new UserRouteBuilder().IdentityProvider("windows").SubjectId("first.last").UserGroupsRoute;
-            Assert.Equal($"/{RouteConstants.UserRoute}/windows/first.last/{RouteConstants.GroupCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.UserRoute}/windows/first.last/{RouteConstants.GroupCollectionRoute}", route);
         }
 
         [Fact]
         public void UserRouteBuilderRolesRoute_WithUserId_Success()
         {
             var route = new UserRouteBuilder().IdentityProvider("windows").SubjectId("first.last").UserRolesRoute;
-            Assert.Equal($"/{RouteConstants.UserRoute}/windows/first.last/{RouteConstants.RoleCollectionRoute}", route);
+            Assert.Equal($"{RouteConstants.UserRoute}/windows/first.last/{RouteConstants.RoleCollectionRoute}", route);
         }
 
         [Fact]
         public void UserPermissionsRouteBuilder_NoOptions_Success()
         {
             var actualRoute = new UserRouteBuilder().UserPermissionsRoute;
-            var expectedRoute = $"/{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}";
+            var expectedRoute = $"{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}";
             Assert.Equal(expectedRoute, actualRoute);
         }
 
@@ -60,7 +60,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         {
             var securableItem = "unit-test";
             var actualRoute = new UserRouteBuilder().SecurableItem(securableItem).UserPermissionsRoute;
-            var expectedRoute = $"/{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}?{ClientConstants.SecurableItem}={securableItem}";
+            var expectedRoute = $"{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}?{ClientConstants.SecurableItem}={securableItem}";
             Assert.Equal(expectedRoute, actualRoute);
         }
 
@@ -69,7 +69,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
         {
             var grain = "app";
             var actualRoute = new UserRouteBuilder().Grain(grain).UserPermissionsRoute;
-            var expectedRoute = $"/{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}?{ClientConstants.Grain}={grain}";
+            var expectedRoute = $"{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}?{ClientConstants.Grain}={grain}";
             Assert.Equal(expectedRoute, actualRoute);
         }
 
@@ -79,7 +79,7 @@ namespace Catalyst.Fabric.Authorization.Client.UnitTests.Routes
             var grain = "app";
             var securableItem = "unit-test";
             var actualRoute = new UserRouteBuilder().Grain(grain).SecurableItem(securableItem).UserPermissionsRoute;
-            var expectedRoute = $"/{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}?{ClientConstants.Grain}={grain}&{ClientConstants.SecurableItem}={securableItem}";
+            var expectedRoute = $"{RouteConstants.UserRoute}/{RouteConstants.PermissionCollectionRoute}?{ClientConstants.Grain}={grain}&{ClientConstants.SecurableItem}={securableItem}";
             Assert.Equal(expectedRoute, actualRoute);
         }
     }

--- a/Catalyst.Fabric.Authorization.Client/AuthorizationClient.cs
+++ b/Catalyst.Fabric.Authorization.Client/AuthorizationClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -18,9 +19,9 @@ namespace Catalyst.Fabric.Authorization.Client
 
         public AuthorizationClient(HttpClient client)
         {
-            this._client = client;
+            this._client = client.FormatBaseUrl();
         }
-
+        
         #region Users
 
         public async Task<UserApiModel> AddUser(string accessToken, UserApiModel userModel)
@@ -359,6 +360,15 @@ namespace Catalyst.Fabric.Authorization.Client
                     Code = response.StatusCode.ToString()
                 };
 
+                throw new AuthorizationException(error);
+            }
+            catch (JsonReaderException)
+            {
+                var error = new Error
+                {
+                    Code = response.StatusCode.ToString(),
+                    Message = stringResponse
+                };
                 throw new AuthorizationException(error);
             }
             catch(JsonSerializationException)

--- a/Catalyst.Fabric.Authorization.Client/Extensions/AuthorizationExtensions.cs
+++ b/Catalyst.Fabric.Authorization.Client/Extensions/AuthorizationExtensions.cs
@@ -1,11 +1,13 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Linq;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using Newtonsoft.Json;
 
 namespace Catalyst.Fabric.Authorization.Client.Extensions
 {
-    internal static class HttpRequestMessageExtensions
+    internal static class AuthorizationExtensions
     {
         public static HttpRequestMessage AddBearerToken(this HttpRequestMessage httpRequestMessage, string accessToken)
         {
@@ -23,6 +25,16 @@ namespace Catalyst.Fabric.Authorization.Client.Extensions
         {
             httpRequestMessage.Content = new StringContent(JsonConvert.SerializeObject(model), Encoding.UTF8, mediaType);
             return httpRequestMessage;
+        }
+
+        public static HttpClient FormatBaseUrl(this HttpClient client)
+        {
+            // so this will trim the forward slash whether its there or not.  it will 
+            // also fix any additional forward slashes.  Once it has trimmed the end,
+            // it will append the forward slash needed for making accurate calls.
+            // see also: https://stackoverflow.com/questions/23438416/why-is-httpclient-baseaddress-not-working#23438417
+            client.BaseAddress = new Uri($"{client.BaseAddress.OriginalString.TrimEnd('/')}/");
+            return client;
         }
     }
 }

--- a/Catalyst.Fabric.Authorization.Client/Routes/BaseRoute.cs
+++ b/Catalyst.Fabric.Authorization.Client/Routes/BaseRoute.cs
@@ -4,6 +4,10 @@
     {
         protected abstract string CollectionType { get; }
 
-        protected virtual string BaseRouteSegment => $"/{CollectionType}";
+        /// <summary>
+        /// General note, do not add a forward slash to the beginning of a relative paths.  it is for reference to this article:
+        /// https://stackoverflow.com/questions/23438416/why-is-httpclient-baseaddress-not-working#23438417
+        /// </summary>
+        protected virtual string BaseRouteSegment => $"{CollectionType}";
     }
 }


### PR DESCRIPTION
This corrects the issue where forward slashes cause processing incorrect urls.

1. base url needs to have a forward slash
2. relative url paths should not have a forward slash at the beginning

I have updated the unit tests to reflect both scenarios.