### PR TITLE
Added retry and circuitbreaker logic

### DIFF
--- a/Catalyst.Fabric.Authorization.Client/AuthorizationClient.cs
+++ b/Catalyst.Fabric.Authorization.Client/AuthorizationClient.cs
@@ -3,38 +3,90 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Catalyst.Fabric.Authorization.Client.Extensions;
 using Catalyst.Fabric.Authorization.Client.Routes;
 using Catalyst.Fabric.Authorization.Models;
 using Catalyst.Fabric.Authorization.Models.Requests;
 using Newtonsoft.Json;
+using Polly;
 
 namespace Catalyst.Fabric.Authorization.Client
 {
     public class AuthorizationClient
     {
-        
+        private Policy RetryPolicy;
+        private Policy CircuitBreakerPolicy;
+
+        private int MaxRetryAttempts;
+
+        private int TimeSpanInMinutes;
+
+        private int NumberOfErrorsBeforeCircuitBreak;
+
         private readonly HttpClient _client;
 
-        public AuthorizationClient(HttpClient client)
+        public AuthorizationClient(HttpClient client, bool useCircuitBreaker = false, bool useRetry = false)
         {
             this._client = client.FormatBaseUrl();
+            
+            if(useCircuitBreaker)
+            {
+                this.InitializeCircuitBreaker();
+            }
+
+            if(useRetry)
+            {
+                this.InitializeRetry();
+            }
         }
-        
+
+        public AuthorizationClient(HttpClient client, bool useCircuitBreaker = false, bool useRetry = false, int maxRetryAttempts = 5, int timeSpanInMinutes = 1, int numberOfErrorsBeforeCircuitBreak = 200)
+            : this(client, useCircuitBreaker, useRetry)
+        {
+            this.MaxRetryAttempts = maxRetryAttempts;
+            this.TimeSpanInMinutes = timeSpanInMinutes;
+            this.NumberOfErrorsBeforeCircuitBreak = numberOfErrorsBeforeCircuitBreak;
+        }
+
+        private void InitializeCircuitBreaker()
+        {
+            // if there is any Authorization Exception,
+            // AggregrateException or OptionationCanceledException,
+            // and there are 200 in one minute, it will trigger the
+            // circuit breaker;
+            this.CircuitBreakerPolicy = Policy.Handle<OperationCanceledException>()
+                .Or<AuthorizationException>()
+                .Or<OperationCanceledException>()
+                .CircuitBreakerAsync(this.NumberOfErrorsBeforeCircuitBreak, TimeSpan.FromMinutes(this.TimeSpanInMinutes));
+        }
+
+        private void InitializeRetry()
+        {
+            // if the exception is a 500 server error of any kind,
+            // do a retry just to make sure.
+            // Everything else, just fail.
+            // if there are too many 500 errors, then circuit break.
+            this.RetryPolicy = Policy.Handle<OperationCanceledException>()
+                .Or<AuthorizationException>(auth => auth.Details.Code.First() == '5' && auth.Details.Code.Length == 3)
+                .Or<OperationCanceledException>()
+                .WaitAndRetryAsync(this.MaxRetryAttempts, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+        }
+
         #region Users
 
-        public async Task<UserApiModel> AddUser(string accessToken, UserApiModel userModel)
+        public async Task<UserApiModel> AddUser(string accessToken, UserApiModel userModel, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, new UserRouteBuilder().Route)
                 .AddContent(userModel)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<UserApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<UserApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<UserPermissionsApiModel> GetPermissionsForCurrentUser(string accessToken, string grain = "", string securableItem = "")
+        public async Task<UserPermissionsApiModel> GetPermissionsForCurrentUser(string accessToken, string grain = "", string securableItem = "", CancellationToken? token = null)
         {
             CheckIfStringNullOrEmpty(accessToken, nameof(accessToken));
 
@@ -46,15 +98,15 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddBearerToken(accessToken)
                 .AddAcceptHeader();
 
-            return await SendAndParseJson<UserPermissionsApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<UserPermissionsApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<bool> DoesUserHavePermission(string accessToken, string permission)
+        public async Task<bool> DoesUserHavePermission(string accessToken, string permission, CancellationToken? token = null)
         {
             CheckIfStringNullOrEmpty(accessToken, nameof(accessToken));
             CheckIfStringNullOrEmpty(permission, nameof(permission));
 
-            var userPermissions = await this.GetPermissionsForCurrentUser(accessToken).ConfigureAwait(false);
+            var userPermissions = await this.GetPermissionsForCurrentUser(accessToken, token: token).ConfigureAwait(false);
             return DoesUserHavePermission(userPermissions, permission);
         }
 
@@ -70,17 +122,17 @@ namespace Catalyst.Fabric.Authorization.Client
             return userPermissions.Permissions.Any(p => p == permission);
         }
 
-        public async Task<List<PermissionApiModel>> GetUserPermissions(string accessToken, string identityProvider, string subjectId)
+        public async Task<List<PermissionApiModel>> GetUserPermissions(string accessToken, string identityProvider, string subjectId, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Get,
                     new UserRouteBuilder().IdentityProvider(identityProvider).SubjectId(subjectId).UserPermissionsRoute)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<List<PermissionApiModel>>(message).ConfigureAwait(false);
+            return await SendAndParseJson<List<PermissionApiModel>>(message, token).ConfigureAwait(false);
         }
 
-        public async Task AddPermissionsToUser(string accessToken, string identityProvider, string subjectId, List<PermissionApiModel> permissionModels)
+        public async Task AddPermissionsToUser(string accessToken, string identityProvider, string subjectId, List<PermissionApiModel> permissionModels, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post,
                 new UserRouteBuilder().IdentityProvider(identityProvider).SubjectId(subjectId).UserPermissionsRoute)
@@ -88,10 +140,10 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            await SendRequest(message).ConfigureAwait(false);
+            await SendRequest(message, token).ConfigureAwait(false);
         }
 
-        public async Task DeletePermissionsFromUser(string accessToken, string identityProvider, string subjectId, List<PermissionApiModel> permissionModels)
+        public async Task DeletePermissionsFromUser(string accessToken, string identityProvider, string subjectId, List<PermissionApiModel> permissionModels, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Delete,
                     new UserRouteBuilder().IdentityProvider(identityProvider).SubjectId(subjectId).UserPermissionsRoute)
@@ -99,10 +151,10 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            await SendRequest(message).ConfigureAwait(false);
+            await SendRequest(message, token).ConfigureAwait(false);
         }
 
-        public async Task<UserApiModel> AddRolesToUser(string accessToken, string identityProvider, string subjectId, List<RoleApiModel> roleModels)
+        public async Task<UserApiModel> AddRolesToUser(string accessToken, string identityProvider, string subjectId, List<RoleApiModel> roleModels, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post,
                     new UserRouteBuilder().IdentityProvider(identityProvider).SubjectId(subjectId).UserRolesRoute)
@@ -110,10 +162,10 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<UserApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<UserApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<UserApiModel> DeleteRolesFromUser(string accessToken, string identityProvider, string subjectId, List<RoleApiModel> roleModels)
+        public async Task<UserApiModel> DeleteRolesFromUser(string accessToken, string identityProvider, string subjectId, List<RoleApiModel> roleModels, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Delete,
                     new UserRouteBuilder().IdentityProvider(identityProvider).SubjectId(subjectId).UserRolesRoute)
@@ -121,154 +173,154 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<UserApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<UserApiModel>(message, token).ConfigureAwait(false);
         }
 
         #endregion
 
         #region Clients
 
-        public async Task<ClientApiModel> AddClient(string accessToken, ClientApiModel clientModel)
+        public async Task<ClientApiModel> AddClient(string accessToken, ClientApiModel clientModel, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, new ClientRouteBuilder().Route)
                 .AddContent(clientModel)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<ClientApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<ClientApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<ClientApiModel> GetClient(string accessToken, string clientId)
+        public async Task<ClientApiModel> GetClient(string accessToken, string clientId, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Get, new ClientRouteBuilder().ClientId(clientId).Route)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<ClientApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<ClientApiModel>(message, token).ConfigureAwait(false);
         }
 
         #endregion
 
         #region Roles
 
-        public async Task<RoleApiModel> AddRole(string accessToken, RoleApiModel roleModel)
+        public async Task<RoleApiModel> AddRole(string accessToken, RoleApiModel roleModel, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, new RoleRouteBuilder().Route)
                 .AddContent(roleModel)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<RoleApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<RoleApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<RoleApiModel> AddPermissionToRole(string accessToken, string roleId, List<PermissionApiModel> permissionModels)
+        public async Task<RoleApiModel> AddPermissionToRole(string accessToken, string roleId, List<PermissionApiModel> permissionModels, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, new RoleRouteBuilder().RoleId(roleId).RolePermissionsRoute)
                 .AddContent(permissionModels)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<RoleApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<RoleApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<RoleApiModel> DeletePermissionsFromRole(string accessToken, string roleId, List<PermissionApiModel> permissionModels)
+        public async Task<RoleApiModel> DeletePermissionsFromRole(string accessToken, string roleId, List<PermissionApiModel> permissionModels, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Delete, new RoleRouteBuilder().RoleId(roleId).RolePermissionsRoute)
                 .AddContent(permissionModels)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<RoleApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<RoleApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<List<RoleApiModel>> GetRole(string accessToken, string grain, string securableItem, string roleName = null)
+        public async Task<List<RoleApiModel>> GetRole(string accessToken, string grain, string securableItem, string roleName = null, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Get,
                     new RoleRouteBuilder().Grain(grain).SecurableItem(securableItem).Name(roleName).Route)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<List<RoleApiModel>>(message).ConfigureAwait(false);
+            return await SendAndParseJson<List<RoleApiModel>>(message, token).ConfigureAwait(false);
         }
 
         #endregion
 
         #region Permissions
 
-        public async Task<PermissionApiModel> AddPermission(string accessToken, PermissionApiModel permissionModel)
+        public async Task<PermissionApiModel> AddPermission(string accessToken, PermissionApiModel permissionModel, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, new PermissionRouteBuilder().Route)
                 .AddContent(permissionModel)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<PermissionApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<PermissionApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<PermissionApiModel> GetPermission(string accessToken, string permissionId)
+        public async Task<PermissionApiModel> GetPermission(string accessToken, string permissionId, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Get,
                     new PermissionRouteBuilder().PermissionId(permissionId).Route)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<PermissionApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<PermissionApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<List<PermissionApiModel>> GetPermissions(string accessToken, string grain, string securableItem, string permissionName = null)
+        public async Task<List<PermissionApiModel>> GetPermissions(string accessToken, string grain, string securableItem, string permissionName = null, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Get,
                     new PermissionRouteBuilder().Grain(grain).SecurableItem(securableItem).Name(permissionName).Route)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<List<PermissionApiModel>>(message).ConfigureAwait(false);
+            return await SendAndParseJson<List<PermissionApiModel>>(message, token).ConfigureAwait(false);
         }
 
         #endregion
 
         #region Groups
 
-        public async Task<GroupRoleApiModel> GetGroup(string accessToken, string groupName)
+        public async Task<GroupRoleApiModel> GetGroup(string accessToken, string groupName, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Get, new GroupRouteBuilder().Name(groupName).Route)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<GroupRoleApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<GroupRoleApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<List<RoleApiModel>> GetGroupRoles(string accessToken, string groupName)
+        public async Task<List<RoleApiModel>> GetGroupRoles(string accessToken, string groupName, CancellationToken? token = null)
         {
             var message =
                 new HttpRequestMessage(HttpMethod.Get, new GroupRouteBuilder().Name(groupName).GroupRolesRoute)
                     .AddAcceptHeader()
                     .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<List<RoleApiModel>>(message).ConfigureAwait(false);
+            return await SendAndParseJson<List<RoleApiModel>>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<List<RoleApiModel>> GetGroupRoles(string accessToken, string groupName, string grain, string securableItem)
+        public async Task<List<RoleApiModel>> GetGroupRoles(string accessToken, string groupName, string grain, string securableItem, CancellationToken? token = null)
         {
             var message =
                 new HttpRequestMessage(HttpMethod.Get, new GroupRouteBuilder().Name(groupName).GroupRolesRoute)
                     .AddAcceptHeader()
                     .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<List<RoleApiModel>>(message).ConfigureAwait(false);
+            return await SendAndParseJson<List<RoleApiModel>>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<GroupRoleApiModel> AddGroup(string accessToken, GroupRoleApiModel groupModel)
+        public async Task<GroupRoleApiModel> AddGroup(string accessToken, GroupRoleApiModel groupModel, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post, new GroupRouteBuilder().Route)
                 .AddContent(groupModel)
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<GroupRoleApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<GroupRoleApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<GroupRoleApiModel> AddRolesToGroup(string accessToken, string groupName, List<RoleApiModel> roleModels)
+        public async Task<GroupRoleApiModel> AddRolesToGroup(string accessToken, string groupName, List<RoleApiModel> roleModels, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post,
                     new GroupRouteBuilder().Name(groupName).GroupRolesRoute)
@@ -276,10 +328,10 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<GroupRoleApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<GroupRoleApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<GroupRoleApiModel> DeleteRolesFromGroup(string accessToken, string groupName, List<RoleIdentifierApiRequest> roleIds)
+        public async Task<GroupRoleApiModel> DeleteRolesFromGroup(string accessToken, string groupName, List<RoleIdentifierApiRequest> roleIds, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Delete,
                     new GroupRouteBuilder().Name(groupName).GroupRolesRoute)
@@ -287,10 +339,10 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<GroupRoleApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<GroupRoleApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<GroupUserApiModel> AddUsersToGroup(string accessToken, string groupName, List<UserIdentifierApiRequest> userIds)
+        public async Task<GroupUserApiModel> AddUsersToGroup(string accessToken, string groupName, List<UserIdentifierApiRequest> userIds, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Post,
                     new GroupRouteBuilder().Name(groupName).GroupUsersRoute)
@@ -298,10 +350,10 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<GroupUserApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<GroupUserApiModel>(message, token).ConfigureAwait(false);
         }
 
-        public async Task<GroupUserApiModel> DeleteUserFromGroup(string accessToken, string groupName, GroupUserRequest user)
+        public async Task<GroupUserApiModel> DeleteUserFromGroup(string accessToken, string groupName, GroupUserRequest user, CancellationToken? token = null)
         {
             var message = new HttpRequestMessage(HttpMethod.Delete,
                     new GroupRouteBuilder().Name(groupName).GroupUsersRoute)
@@ -309,7 +361,7 @@ namespace Catalyst.Fabric.Authorization.Client
                 .AddAcceptHeader()
                 .AddBearerToken(accessToken);
 
-            return await SendAndParseJson<GroupUserApiModel>(message).ConfigureAwait(false);
+            return await SendAndParseJson<GroupUserApiModel>(message, token).ConfigureAwait(false);
         }
 
         #endregion
@@ -340,9 +392,33 @@ namespace Catalyst.Fabric.Authorization.Client
             }
         }
 
-        private async Task<T> SendAndParseJson<T>(HttpRequestMessage message)
+        private async Task<T> SendAndParseJson<T>(HttpRequestMessage message, CancellationToken? token)
         {
-            var response = await _client.SendAsync(message).ConfigureAwait(false);
+            // This function wraps all the retry/circuit breaker logic
+            // for the sending of a request.
+            
+            // retry first a few times.
+            var RetryTask = RetryPolicy.ExecuteAsync<T>(
+                () => this.SendAndParseJsonImpl<T>(message, token));
+            
+            // if the retry doesnt work, create circuit breaker
+            // logic
+            return await CircuitBreakerPolicy.ExecuteAsync<T>(
+                async () => await RetryTask
+            );
+        }
+
+        private async Task<T> SendAndParseJsonImpl<T>(HttpRequestMessage message, CancellationToken? token)
+        {
+            var response = new HttpResponseMessage();
+            if(token.HasValue)
+            {
+                response = await _client.SendAsync(message).ConfigureAwait(false);
+            }
+            else
+            {
+                response = await _client.SendAsync(message, token.Value).ConfigureAwait(false);   
+            }
             var stringResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)
@@ -382,9 +458,34 @@ namespace Catalyst.Fabric.Authorization.Client
             }
         }
 
-        private async Task SendRequest(HttpRequestMessage message)
+        private async Task SendRequest(HttpRequestMessage message, CancellationToken? token)
         {
-            var response = await _client.SendAsync(message).ConfigureAwait(false);
+            // This function wraps all the retry/circuit breaker logic
+            // for the sending of a request.
+
+            // retry first a few times.
+            var RetryTask = RetryPolicy.ExecuteAsync(
+                () => this.SendRequestImpl(message, token));
+            
+            // if the retry doesnt work, create circuit breaker
+            // logic
+            await CircuitBreakerPolicy.ExecuteAsync(
+                async () => await RetryTask
+            );
+        }
+
+        private async Task SendRequestImpl(HttpRequestMessage message, CancellationToken? token)
+        {
+            var response = new HttpResponseMessage();
+            if(token.HasValue)
+            {
+                response = await _client.SendAsync(message).ConfigureAwait(false);
+            }
+            else
+            {
+                response = await _client.SendAsync(message, token.Value).ConfigureAwait(false);   
+            }
+            
             var stringResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)

--- a/Catalyst.Fabric.Authorization.Client/Catalyst.Fabric.Authorization.Client.csproj
+++ b/Catalyst.Fabric.Authorization.Client/Catalyst.Fabric.Authorization.Client.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.2" />
+    <PackageReference Include="Polly" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Needs some testing and attention to the exception scenarios that we need to capture, but this is a foundation for introducing Polly (retry and circuit breaker logic) into our API.

I added an optional cancellation token as well to match what HttpClient does for it's web requests.

Basically, if you are a 500, a cancelled task or timeout, then we should try to retry the request with an exponential backoff (i.e. 1, 2, 4, 8, etc).

Now, if you encounter so many failures within a minute (like 200) then we should stop processing a request and throw a circuit breaker exception.  This is so we dont DDOS our service.  After a cool down, then it will test to make sure it can access the resource again.

Anyways, this is a start.  perhaps something to make a story out of it.