### PR TITLE
Migrate dosadmin role to DataMartAdmin

### DIFF
--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -165,11 +165,11 @@ function Add-UserToGroup($group, $user, $connString)
     Invoke-Sql $connString $query @{groupId = $groupId; identityProvider = $identityProvider; subjectId = $subjectId} | Out-Null
 }
 
-function Add-GroupToGroup($parentGroup, $childGroup, $connString)
+function Add-ChildGroupToParentGroup($parentGroup, $childGroup, $connString)
 {
     $query = "INSERT INTO ChildGroups
               (ParentGroupId, ChildGroupId, CreatedBy, CreatedDateTimeUtc)
-              VALUES(@parentGroupId, @childGroupId, 'fabric-installer', GETDATEUTC()"
+              VALUES(@parentGroupId, @childGroupId, 'fabric-installer', GETUTCDATE())"
 
     $parentGroupId = $parentGroup.Id
     $childGroupId = $childGroup.Id
@@ -250,7 +250,7 @@ function Add-AccountToDosAdminGroup($accountName, $domain, $authorizationService
     elseif (Test-IsGroup -samAccountName $samAccountName -domain $domain) {
         try {
             $childGroup = Add-Group -authUrl $authorizationServiceUrl -name $accountName -source "Windows" -accessToken $accessToken
-            Add-GroupToGroup -parentGroup $group -childGroup $childGroup -connString $connString
+            Add-ChildGroupToParentGroup -parentGroup $group -childGroup $childGroup -connString $connString
         }
         catch {
             $exception = $_.Exception

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -546,8 +546,8 @@ function Move-DosAdminRoleToDosAdminGroup($authUrl, $accessToken, $connectionStr
     Remove-GroupsFromDosAdminRole -connectionString $connectionString -clientId $fabricInstallerClientId -roleName $dosAdminRole -securableName $dataMartsSecurable
     if((Test-FabricRegistrationStepAlreadyComplete -authUrl $authUrl -accessToken $accessToken)){
         Remove-DosAdminRole -connectionString $connectionString -clientId $fabricInstallerClientId -roleName $dosAdminRole -securableName $dataMartsSecurable
-        $dataMartAdminRole = Get-Role -name $dataMartAdminRole -grain $dosGrain -securableItem $dataMartsSecurable -authorizationServiceUrl $authUrl -accessToken $accessToken
-        Add-RoleToGroup -role $dataMartAdminRole -group $group -connString $connectionString -clientId $fabricInstallerClientId
+        $dataMartAdminRoleModel = Get-Role -name $dataMartAdminRole -grain $dosGrain -securableItem $dataMartsSecurable -authorizationServiceUrl $authUrl -accessToken $accessToken
+        Add-RoleToGroup -role $dataMartAdminRoleModel -group $group -connString $connectionString -clientId $fabricInstallerClientId
     }
     else{
         Add-DosAdminRoleToDosAdminGroup -groupId $groupId -connectionString $connectionString -clientId $fabricInstallerClientId -roleName $dosAdminRole -securableName $dataMartsSecurable

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -306,7 +306,7 @@ function Get-EdwAdminUsersAndGroups($connectionString) {
     return $usersAndGroups;	
 }	
     	
-function Add-ListOfUsersToDosAdminRole($edwAdminUsers, $connString, $authorizationServiceUrl, $accessToken) {	   
+function Add-ListOfUsersToDosAdminGroup($edwAdminUsers, $connString, $authorizationServiceUrl, $accessToken) {	   
     # Get the group once, should be same for every user.
     $group = Get-Group -name $dosAdminGroupName -authorizationServiceUrl $authorizationServiceUrl -accessToken $accessToken
 
@@ -1048,7 +1048,7 @@ Write-Host "Upgrading all the users with an 'EDW Admin' role to also be a member
 $edwAdminUsers = Get-EdwAdminUsersAndGroups -connectionString $metadataConnStr	
 Write-Host "There are $($edwAdminUsers.Count) users with this role"	
 Write-Host ""	
-Add-ListOfUsersToDosAdminRole -edwAdminUsers $edwAdminUsers -connString $authorizationDbConnStr -authorizationServiceUrl "$authorizationServiceUrl/v1" -accessToken $accessToken
+Add-ListOfUsersToDosAdminGroup -edwAdminUsers $edwAdminUsers -connString $authorizationDbConnStr -authorizationServiceUrl "$authorizationServiceUrl/v1" -accessToken $accessToken
 
 
 $corsOrigin = Get-FullyQualifiedMachineName

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -161,8 +161,8 @@ function Add-RoleToUser($role, $user, $connString, $clientId) {
 function Add-UserToGroup($group, $user, $connString, $clientId)
 {
     $query = "INSERT INTO GroupUsers
-             (CreatedBy, CreatedDateTimeUtc, GroupId, IdentityProvider, SubjectId)
-             VALUES(@clientId, GETUTCDATE(), @groupId, @identityProvider, @subjectId)"
+             (CreatedBy, CreatedDateTimeUtc, GroupId, IdentityProvider, SubjectId, IsDeleted)
+             VALUES(@clientId, GETUTCDATE(), @groupId, @identityProvider, @subjectId, 0)"
 
     $groupId = $group.Id
     $identityProvider = $user.identityProvider
@@ -173,8 +173,8 @@ function Add-UserToGroup($group, $user, $connString, $clientId)
 function Add-ChildGroupToParentGroup($parentGroup, $childGroup, $connString, $clientId)
 {
     $query = "INSERT INTO ChildGroups
-              (ParentGroupId, ChildGroupId, CreatedBy, CreatedDateTimeUtc)
-              VALUES(@parentGroupId, @childGroupId, @clientId, GETUTCDATE())"
+              (ParentGroupId, ChildGroupId, CreatedBy, CreatedDateTimeUtc, IsDeleted)
+              VALUES(@parentGroupId, @childGroupId, @clientId, GETUTCDATE(), 0)"
 
     $parentGroupId = $parentGroup.Id
     $childGroupId = $childGroup.Id

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Windows.ps1
@@ -548,7 +548,7 @@ else {
 }
 
 if ([string]::IsNullOrEmpty($installSettings.authorizationService)) {
-    $authorizationServiceUrl = "Get-FullyQualifiedMachineName()/Authorization"
+    $authorizationServiceUrl = "$(Get-FullyQualifiedMachineName)/Authorization"
 }
 else {
     $authorizationServiceUrl = $installSettings.authorizationService

--- a/Fabric.Authorization.Domain/Defaults/Authorization.cs
+++ b/Fabric.Authorization.Domain/Defaults/Authorization.cs
@@ -51,8 +51,8 @@ namespace Fabric.Authorization.Domain.Defaults
             {
                 new Role
                 {
-                    Name = "dosadmin",
-                    DisplayName = "DOS Admin",
+                    Name = "datamartadmin",
+                    DisplayName = "Datamart Admin",
                     Description = "Create, read, update, and delete Metadata and System Attributes. Read access to Metadata Audit logs.",
                     Grain = DosGrain,
                     SecurableItem = "datamarts",

--- a/Fabric.Authorization.IntegrationTests/Modules/DosTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Modules/DosTests.cs
@@ -32,7 +32,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         public async Task AddDosPermission_UserInRole_SuccessAsync()
         {
             var user = "user" + Guid.NewGuid();
-            await AssociateUserToDosAdminRoleAsync(user);
+            await AssociateUserToDataMartAdminRoleAsync(user);
 
             var clientId = "clientid" + Guid.NewGuid();
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
@@ -171,7 +171,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
         public async Task AddDosPermission_UserInRole_MissingScope_ForbiddenAsync()
         {
             var user = "user" + Guid.NewGuid();
-            await AssociateUserToDosAdminRoleAsync(user);
+            await AssociateUserToDataMartAdminRoleAsync(user);
 
             var clientId = "clientid" + Guid.NewGuid();
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
@@ -293,7 +293,7 @@ namespace Fabric.Authorization.IntegrationTests.Modules
             Assert.Equal(HttpStatusCode.BadRequest, postResponse.StatusCode);
         }
 
-        private async Task AssociateUserToDosAdminRoleAsync(string user)
+        private async Task AssociateUserToDataMartAdminRoleAsync(string user)
         {
             var clientId = "fabric-installer";
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
@@ -307,13 +307,13 @@ namespace Fabric.Authorization.IntegrationTests.Modules
 
             var browser = _fixture.GetBrowser(principal, _storageProvider);
 
-            var roleResponse = await browser.Get("/roles/dos/datamarts/dosadmin", with =>
+            var roleResponse = await browser.Get("/roles/dos/datamarts/datamartadmin", with =>
                 {
                     with.HttpRequest();
                 });
             Assert.Equal(HttpStatusCode.OK, roleResponse.StatusCode);
             var role = JsonConvert.DeserializeObject<List<RoleApiModel>>(roleResponse.Body.AsString()).First();
-            Assert.Equal("dosadmin", role.Name);
+            Assert.Equal("datamartadmin", role.Name);
 
             var groupResponse = await browser.Post("/groups", with =>
             {

--- a/Fabric.Authorization.UnitTests/DbBootstrappers/SqlServerDbBootstrapperTests.cs
+++ b/Fabric.Authorization.UnitTests/DbBootstrappers/SqlServerDbBootstrapperTests.cs
@@ -61,7 +61,7 @@ namespace Fabric.Authorization.UnitTests.DbBootstrappers
             var roles = dbContext.Roles
                 .Include(r => r.RolePermissions)
                 .ThenInclude(rp => rp.Permission)
-                .Where(r => r.Name == "dosadmin")
+                .Where(r => r.Name == "datamartadmin")
                 .ToList();
 
             var rolePermissions = roles.SelectMany(r => r.RolePermissions).ToList();


### PR DESCRIPTION
Associate the DataMartAdmin role to the DosAdmin group.
Move users/groups associated w/ the deprecated dosadmin role to the DosAdmin group.
Handle the case where someone may run the Fabric.Registration step before the Fabric.Authorization installation step.