### PR TITLE
Enable polyfills for IE

### DIFF
--- a/Fabric.Authorization.AccessControl/src/polyfills.ts
+++ b/Fabric.Authorization.AccessControl/src/polyfills.ts
@@ -26,9 +26,9 @@
 // import 'core-js/es6/parse-float';
 // import 'core-js/es6/number';
 // import 'core-js/es6/math';
-// import 'core-js/es6/string';
+import 'core-js/es6/string';
 // import 'core-js/es6/date';
-// import 'core-js/es6/array';
+import 'core-js/es6/array';
 // import 'core-js/es6/regexp';
 // import 'core-js/es6/map';
 // import 'core-js/es6/weak-map';


### PR DESCRIPTION
There are some minor UI issues with IE left over, such as search boxes not being sized correctly