### PR TITLE
IE no-cache required headers

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/services/interceptors/index.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/interceptors/index.ts
@@ -2,6 +2,7 @@
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { FabricHttpRequestInterceptorService } from './fabric-http-request-interceptor.service';
 import { FabricHttpErrorHandlerInterceptorService } from './fabric-http-error-handler-interceptor.service';
+import { StandardHeaderInterceptor } from './standard-header-interceptor';
 
 /** Http interceptor providers in outside-in order */
 export const httpInterceptorProviders = [
@@ -13,6 +14,11 @@ export const httpInterceptorProviders = [
   {
     provide: HTTP_INTERCEPTORS,
     useClass: FabricHttpErrorHandlerInterceptorService,
+    multi: true
+  },
+  {
+    provide: HTTP_INTERCEPTORS,
+    useClass: StandardHeaderInterceptor,
     multi: true
   }
 ];

--- a/Fabric.Authorization.AccessControl/src/app/services/interceptors/standard-header-interceptor.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/interceptors/standard-header-interceptor.ts
@@ -10,8 +10,6 @@ export class StandardHeaderInterceptor implements HttpInterceptor {
         // IE requires Pragma, Expires, and If-Modified-Since headers to NOT cache results, so we need to add these headers on requests
         const genericReq: HttpRequest<any> = req.clone({
             headers: req.headers
-                .set('Accept', 'application/json')
-                .set('Content-Type', 'application/json')
                 .set('Pragma', 'no-cache')
                 .set('Expires', 'Sat, 01 Jan 2000 00:00:00 GMT')
                 .set('If-Modified-Since', '0')

--- a/Fabric.Authorization.AccessControl/src/app/services/interceptors/standard-header-interceptor.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/interceptors/standard-header-interceptor.ts
@@ -1,0 +1,22 @@
+import { Injectable, Injector } from '@angular/core';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable()
+export class StandardHeaderInterceptor implements HttpInterceptor {
+    constructor(private injector: Injector) {}
+
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        // IE requires Pragma, Expires, and If-Modified-Since headers to NOT cache results, so we need to add these headers on requests
+        const genericReq: HttpRequest<any> = req.clone({
+            headers: req.headers
+                .set('Accept', 'application/json')
+                .set('Content-Type', 'application/json')
+                .set('Pragma', 'no-cache')
+                .set('Expires', 'Sat, 01 Jan 2000 00:00:00 GMT')
+                .set('If-Modified-Since', '0')
+        });
+
+        return next.handle(genericReq);
+    }
+}


### PR DESCRIPTION
Do not cache any requests made from access-control
