### PR TITLE
favicon off absolute path from root for edge(/ie bookmarking)

### DIFF
--- a/Fabric.Authorization.AccessControl/src/index.html
+++ b/Fabric.Authorization.AccessControl/src/index.html
@@ -6,7 +6,7 @@
   <base href="CLIENT_ROOT">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/x-icon" href="/client/favicon.ico">
   <script>
     window.discoveryServiceRoot = "DISCOVERY_SERVICE_ROOT";
   </script>


### PR DESCRIPTION
Fixes the disappearing edge favicon which was caused because edge would request the favicon based on the page the browser was on instead of off the root

e.g. `/client/access-control-dos/favicon.ico` when on any dos grain securable instead of `/client/favicon.ico`
