### PR TITLE
Added function to display a group or user name

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.html
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.html
@@ -35,7 +35,7 @@
       <hc-icon fontSet="fa" fontIcon="fa-filter"></hc-icon>
     </div>
   </div>
-  
+
   <div>
     <hc-progress-spinner *ngIf="searchesInProgress > 0" [diameter]="30" [color]="'blue'" [hasChannel]="true" [isCentered]="true"
       [isDeterminate]="false">
@@ -64,7 +64,7 @@
       <tbody>
         <tr *ngFor="let member of members">
           <td>
-            <a (click)="goToMemberEdit(member)">{{member.displayName}}</a>
+            <a (click)="goToMemberEdit(member)">{{ getMemberNameToDisplay(member) }}</a>
           </td>
           <td>{{member.entityType}}</td>
           <td>{{selectRoleNames(member.roles).join(', ')}}</td>

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.spec.ts
@@ -9,6 +9,7 @@ import { FabricAuthMemberSearchServiceMock, mockAuthSearchResult } from '../../.
 import { Observable } from 'rxjs/Observable';
 import { FormsModule } from '@angular/forms';
 import { FabricAuthMemberSearchService } from '../../../services/fabric-auth-member-search.service';
+import { IAuthMemberSearchResult } from '../../../models/authMemberSearchResult.model';
 
 describe('MemberListComponent', () => {
   let component: MemberListComponent;
@@ -45,5 +46,100 @@ describe('MemberListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('getMemberNameToDisplay', () => {
+
+    it('should return the display name if exist', () => {
+      // Arrange
+      const displayName = 'displayName';
+      const member = {
+        displayName: displayName,
+        groupName: 'groupName',
+        subjectId: '1',
+        identityProvider: 'test',
+        roles: null,
+        firstName: 'test',
+        middleName: 'test',
+        lastName: 'test',
+        lastLoginDateTimeUtc: null,
+        entityType: null,
+        name: null
+      };
+      // Act
+      const result = component.getMemberNameToDisplay(member);
+
+      // Assert
+      expect(result).toBe(displayName);
+    });
+
+    it('should return the group name if exist and display name is null', () => {
+      // Arrange
+      const groupName = 'groupName';
+      const member = {
+        displayName: null,
+        groupName: groupName,
+        subjectId: '1',
+        identityProvider: 'test',
+        roles: null,
+        firstName: 'test',
+        middleName: 'test',
+        lastName: 'test',
+        lastLoginDateTimeUtc: null,
+        entityType: null,
+        name: null
+      };
+      // Act
+      const result = component.getMemberNameToDisplay(member);
+
+      // Assert
+      expect(result).toBe(groupName);
+    });
+
+    it('should return the group name if exist and display name is undefined', () => {
+      // Arrange
+      const groupName = 'groupName';
+      const member = {
+        displayName: undefined,
+        groupName: groupName,
+        subjectId: '1',
+        identityProvider: 'test',
+        roles: null,
+        firstName: 'test',
+        middleName: 'test',
+        lastName: 'test',
+        lastLoginDateTimeUtc: null,
+        entityType: null,
+        name: null
+      };
+      // Act
+      const result = component.getMemberNameToDisplay(member);
+
+      // Assert
+      expect(result).toBe(groupName);
+    });
+
+    it('should return the group name if exist and display name is empty string', () => {
+      // Arrange
+      const groupName = '';
+      const member = {
+        displayName: undefined,
+        groupName: groupName,
+        subjectId: '1',
+        identityProvider: 'test',
+        roles: null,
+        firstName: 'test',
+        middleName: 'test',
+        lastName: 'test',
+        lastLoginDateTimeUtc: null,
+        entityType: null,
+        name: null
+      };
+      // Act
+      const result = component.getMemberNameToDisplay(member);
+
+      // Assert
+      expect(result).toBe(groupName);
+    });
   });
 });

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.ts
@@ -210,6 +210,14 @@ export class MemberListComponent implements OnInit, OnChanges {
         });
     }
   }
+
+  getMemberNameToDisplay(member: IAuthMemberSearchResult): string {
+    if (member.displayName !== '' && member.displayName !== null && member.displayName !== undefined) {
+      return member.displayName;
+    }
+
+    return member.groupName;
+  }
 }
 
 


### PR DESCRIPTION
If displayName was empty, null or undefined, then try to use groupName
If groupName is empty, null or undefined, then display generic value so that the user has a link to click.

If there are other values to display other than group or display name, we can add to this code.