### PR TITLE
Added code to failback to group name for display name

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.html
@@ -12,7 +12,7 @@
         <ul class="member-list">
             <li *ngFor="let group of customGroups">
                 <hc-checkbox [id]="group.id" [(ngModel)]="group.selected" (click)="customGroupSelected(group)"></hc-checkbox>
-                <span [innerText]="group.displayName">
+                <span [innerText]="getGroupNameToDisplay(group)">
                 </span>
             </li>
         </ul>

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.spec.ts
@@ -165,4 +165,91 @@ describe('CustomGroupComponent', () => {
       expect(component.groupNameError).toMatch(`Could not create group named "${mockGroupsResponse[0].groupName}"\.*`);
     });
   });
+
+  describe('getGroupNameToDisplay', () => {
+
+    it('should return the display name if exist', () => {
+      // Arrange
+      const displayName = 'displayName';
+      const group = {
+        displayName: displayName,
+        groupName: 'groupName',
+        id: '1',
+        roles: null,
+        users: null,
+        groupSource: '',
+        description: '',
+        children: null,
+        parents: null
+      };
+      // Act
+      const result = component.getGroupNameToDisplay(group);
+
+      // Assert
+      expect(result).toBe(displayName);
+    });
+
+    it('should return the group name if exist and display name is null', () => {
+      // Arrange
+      const groupName = 'groupName';
+      const group = {
+        displayName: null,
+        groupName: groupName,
+        id: '1',
+        roles: null,
+        users: null,
+        groupSource: '',
+        description: '',
+        children: null,
+        parents: null
+      };
+      // Act
+      const result = component.getGroupNameToDisplay(group);
+
+      // Assert
+      expect(result).toBe(groupName);
+    });
+
+    it('should return the group name if exist and display name is undefined', () => {
+      // Arrange
+      const groupName = 'groupName';
+      const group = {
+        displayName: undefined,
+        groupName: groupName,
+        id: '1',
+        roles: null,
+        users: null,
+        groupSource: '',
+        description: '',
+        children: null,
+        parents: null
+      };
+      // Act
+      const result = component.getGroupNameToDisplay(group);
+
+      // Assert
+      expect(result).toBe(groupName);
+    });
+
+    it('should return the group name if exist and display name is empty string', () => {
+      // Arrange
+      const groupName = '';
+      const group = {
+        displayName: undefined,
+        groupName: groupName,
+        id: '1',
+        roles: null,
+        users: null,
+        groupSource: '',
+        description: '',
+        children: null,
+        parents: null
+      };
+      // Act
+      const result = component.getGroupNameToDisplay(group);
+
+      // Assert
+      expect(result).toBe(groupName);
+    });
+  });
 });

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
@@ -515,4 +515,12 @@ export class CustomGroupComponent implements OnInit, OnDestroy {
         .takeUntil(this.ngUnsubscribe)
         .subscribe();
   }
+
+  getGroupNameToDisplay(customGroup: IGroup): string {
+    if (customGroup.displayName !== '' && customGroup.displayName !== null && customGroup.displayName !== undefined) {
+      return customGroup.displayName;
+    }
+
+    return customGroup.groupName;
+  }
 }


### PR DESCRIPTION
I added the same code but slightly modified from member list.  This just makes sure there is a display name, and if there isnt, then uses group name.

There are tests to verify this.