### PR TITLE
delete duplicate groups before merging to fix SingleOrDefault exception

### DIFF
--- a/Fabric.Authorization.IntegrationTests/Services/GroupMigratorServiceTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Services/GroupMigratorServiceTests.cs
@@ -348,6 +348,7 @@ namespace Fabric.Authorization.IntegrationTests.Services
 
             var results = await groupMigratorService.MigrateDuplicateGroups();
             Assert.Equal(1, results.GroupMigrationRecords.Count);
+            Assert.Empty(results.GroupMigrationRecords.SelectMany(r => r.Errors));
 
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
             {


### PR DESCRIPTION
This bug surfaced in the SqlServer version of the integration test but not the in-memory version since the string equality comparison (`==`) is case sensitive when using the in-memory store so only 1 record was always returned with the query.