### PR TITLE
injected default provider

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
@@ -17,6 +17,7 @@ import { IGroup } from '../../../models/group.model';
 
 import { CurrentUserService } from '../../../services/current-user.service';
 import { AlertService } from '../../../services/global/alert.service';
+import { IAccessControlConfigService } from '../../../services/access-control-config.service';
 
 @Component({
   selector: 'app-custom-group',
@@ -67,7 +68,9 @@ export class CustomGroupComponent implements OnInit, OnDestroy {
     private edwAdminService: FabricAuthEdwAdminService,
     private idpSearchService: FabricExternalIdpSearchService,
     private currentUserService: CurrentUserService,
-    private alertService: AlertService
+    private alertService: AlertService,
+    @Inject('IAccessControlConfigService')
+    private configService: IAccessControlConfigService,
   ) { }
 
   ngOnInit() {
@@ -197,11 +200,13 @@ export class CustomGroupComponent implements OnInit, OnDestroy {
               ? [
                     {
                         subjectId: this.searchTerm,
-                        principalType: this.userType
+                        principalType: this.userType,
+                        identityProvider: this.configService.identityProvider
                     },
                     {
                         subjectId: this.searchTerm,
-                        principalType: this.groupType
+                        principalType: this.groupType,
+                        identityProvider: this.configService.identityProvider
                     }
                 ]
               : result.principals;


### PR DESCRIPTION
I updated the `CustomGroupComponent` to use the config service to get a default identity provider if it needs to create custom child groups and users.