### PR TITLE
Removed mandatory attribute from parameter since there are times this…

### DIFF
--- a/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.psm1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.psm1
@@ -972,7 +972,6 @@ function Add-AccessControlClientRegistration
 
 function Get-AdminAccount{
     param(
-        [Parameter(Mandatory=$true)]
         [string] $adminAccount,
         [Parameter(Mandatory=$true)]
         [string] $currentUserDomain,


### PR DESCRIPTION
… parameter is an empty string and we handle that in the function.