### PR TITLE
Added Azure AD user name parsing for the navbar

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/navbar/navbar.component.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/navbar/navbar.component.spec.ts
@@ -35,25 +35,65 @@ describe('NavbarComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('getUserDisplayName() should return displayName for valid User with given_name and family_name', () => {
-    const user = <User>{};
-    user.profile = {family_name: 'user', given_name: 'test', name: 'domain\test.user'};
-    expect(component.getUserDisplayName(user)).toBe('test user');
+  describe('getUserDisplayName for Windows AD', () => {
+    it('getUserDisplayName() should return displayName for valid User with given_name and family_name', () => {
+      const user = <User>{};
+      user.profile = {family_name: 'user', given_name: 'test', name: 'domain\test.user'};
+      expect(component.getUserDisplayName(user)).toBe('test user');
+    });
+
+    it('getUserDisplayName() should return displayName for valid User with name', () => {
+      const user = <User>{};
+      user.profile = {name: 'domain\test.user'};
+      expect(component.getUserDisplayName(user)).toBe('domain\test.user');
+    });
+
+    it('getUserDisplayName() should return empty string for null User', () => {
+      const user = null;
+      expect(component.getUserDisplayName(user)).toBe('');
+    });
+
+    it('getUserDisplayName() should return empty string for null profile on User', () => {
+      const user = <User>{};
+      expect(component.getUserDisplayName(user)).toBe('');
+    });
   });
 
-  it('getUserDisplayName() should return displayName for valid User with name', () => {
-    const user = <User>{};
-    user.profile = {name: 'domain\test.user'};
-    expect(component.getUserDisplayName(user)).toBe('domain\test.user');
-  });
+  describe('getUserDisplayName for Azure AD', () => {
+    it('getUserDisplayName() should return name if profile.name is not an array', () => {
+      const user = <User>{};
+      user.profile = { idp: 'AzureActiveDirectory', name: 'test user' };
+      expect(component.getUserDisplayName(user)).toBe('test user');
+    });
 
-  it('getUserDisplayName() should return empty string for null User', () => {
-    const user = null;
-    expect(component.getUserDisplayName(user)).toBe('');
-  });
+    it('getUserDisplayName() should return name at 0 if profile.name is an array of 1', () => {
+      const user = <User>{};
+      user.profile = { idp: 'AzureActiveDirectory', name: ['test user'] };
+      expect(component.getUserDisplayName(user)).toBe('test user');
+    });
 
-  it('getUserDisplayName() should return empty string for null profile on User', () => {
-    const user = <User>{};
-    expect(component.getUserDisplayName(user)).toBe('');
+    it('getUserDisplayName() should return index 1 name, and not user principle', () => {
+      const user = <User>{};
+      user.profile = { idp: 'AzureActiveDirectory', name: ['user@test', 'test user'] };
+      expect(component.getUserDisplayName(user)).toBe('test user');
+    });
+
+    it('getUserDisplayName() should return user principle', () => {
+      const user = <User>{};
+      user.profile = { idp: 'AzureActiveDirectory', name: ['user@test'] };
+      expect(component.getUserDisplayName(user)).toBe('user@test');
+    });
+
+    it('getUserDisplayName() no name property returns "no name detected"', () => {
+      const user = <User>{};
+      user.profile = { idp: 'AzureActiveDirectory' };
+      expect(component.getUserDisplayName(user)).toBe('no name detected');
+    });
+
+    it('getUserDisplayName() null name property returns "no name detected"', () => {
+      const user = <User>{};
+      user.profile = { idp: 'AzureActiveDirectory', name: null };
+      expect(component.getUserDisplayName(user)).toBe('no name detected');
+    });
   });
 });

--- a/Fabric.Authorization.AccessControl/src/app/navbar/navbar.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/navbar/navbar.component.ts
@@ -34,10 +34,62 @@ export class NavbarComponent implements OnInit {
     if (user && user.profile) {
       if (user.profile.family_name && user.profile.given_name) {
         return (user.profile.given_name + ' ' + user.profile.family_name);
-      }else {
+      } else if (user.profile.idp === 'AzureActiveDirectory') {
+        return this.parseAzureADProfileName(user.profile);
+      } else {
         return user.profile.name;
       }
     }
     return '';
+  }
+
+  /*
+  Function: parseAzureADProfileName
+    This is complicated code.  Meant to parse the Profile object of a user from
+    Azure AD. It will look to see if it is an array and decided if it is able
+    to find a non-email name.  If it cant find that non-email name then it
+    will use the User Principal name,  i.e. email@domain
+  Parameters: profile, the profile of the user from OIDC
+  Returns: string, the name to use in the nav bar for Azure AD
+  */
+  parseAzureADProfileName(profile: any): string {
+    // 0) if the profile does not have the name property,
+    // then it should return no name detected.  This should
+    // not be the case.
+    if (!profile.hasOwnProperty('name') || profile.name === null) {
+      return 'no name detected';
+    }
+
+    // 1) if the profile does not have an array,
+    // then return the name completely
+    if (!Array.isArray(profile.name)) {
+      return profile.name;
+    }
+
+    // 2) if the profile has 1 item in the array,
+    // then return the first item.
+    if (profile.name.length === 1) {
+      return profile.name[0];
+    } else {
+      // if the profile has multiple items, look for a non-email domain name
+      // 3) if you find it, immediately return it as the name to use.
+      let indexOfUserPrincipal = -1;
+      for (let i = 0; i < profile.name.length; i++ ) {
+        if (profile.name[i].indexOf('@') > 0) {
+          indexOfUserPrincipal = i;
+        } else {
+          return profile.name[i];
+        }
+      }
+
+      // 4) If you dont find the non-email domain name, but you find the
+      // domain name, i.e. name@domain, then use that.
+      // 5) If you cant find anything, then just return the profile name.
+      if (indexOfUserPrincipal > -1) {
+        return profile.name[indexOfUserPrincipal];
+      } else {
+        return profile.name[0];
+      }
+    }
   }
 }


### PR DESCRIPTION
Considering each identity provider will have a different profile object, I split the parsing off for Azure AD.  I more robust solution can come up in the future.

The parsing is a bit tedious, but the code is done.