### PR TITLE
Added code to use identity url instead of discovery

### DIFF
--- a/Fabric.Authorization.API/Configuration/DiscoveryServiceSettings.cs
+++ b/Fabric.Authorization.API/Configuration/DiscoveryServiceSettings.cs
@@ -2,9 +2,11 @@
 {
     public class DiscoveryServiceSettings
     {
-        public string AccessControlToken { get; set; }
-        public bool UseDiscovery { get; set; }
-        public string Endpoint { get; set; }
+        public string DiscoveryServiceToken { get; set; }
         public string IdentityServiceToken { get; set; }
+        public string AccessControlUIToken { get; set; }
+        public bool UseDiscovery { get; set; }
+        public bool UseOAuth2Authentication { get; set; }
+        public string Endpoint { get; set; }
     }
 }

--- a/Fabric.Authorization.API/Infrastructure/Middleware/AngularMiddleware.cs
+++ b/Fabric.Authorization.API/Infrastructure/Middleware/AngularMiddleware.cs
@@ -41,11 +41,18 @@ namespace Fabric.Authorization.API.Infrastructure.Middleware
                 var identityServerSettings = _appConfiguration.IdentityServerConfidentialClientSettings;
 
                 // swaps in the discovery service root
-                _indexContent =
-                    _indexContent.Replace(discoveryServiceSettings.AccessControlToken, discoveryServiceSettings.Endpoint);
-
-                _indexContent = _indexContent.Replace(discoveryServiceSettings.IdentityServiceToken,
-                    identityServerSettings.Authority);
+                if (discoveryServiceSettings.UseOAuth2Authentication)
+                {
+                    _indexContent = _indexContent.Replace(discoveryServiceSettings.DiscoveryServiceToken, string.Empty);
+                    _indexContent = _indexContent.Replace(discoveryServiceSettings.IdentityServiceToken, this._appConfiguration.IdentityServerConfidentialClientSettings.Authority);
+                    _indexContent = _indexContent.Replace(discoveryServiceSettings.AccessControlUIToken, this._appConfiguration.ApplicationEndpoint);
+                }
+                else
+                {
+                    _indexContent = _indexContent.Replace(discoveryServiceSettings.DiscoveryServiceToken, discoveryServiceSettings.Endpoint);
+                    _indexContent = _indexContent.Replace(discoveryServiceSettings.IdentityServiceToken, string.Empty);
+                    _indexContent = _indexContent.Replace(discoveryServiceSettings.AccessControlUIToken, string.Empty);
+                }
 
                 // swaps in the access control root
                 _indexContent = _indexContent.Replace(AccessControl.ClientRootToken,

--- a/Fabric.Authorization.API/appsettings.json
+++ b/Fabric.Authorization.API/appsettings.json
@@ -1,58 +1,60 @@
 {
-  "ClientName": "hc",
-  "StorageProvider": "sqlserver",
-  "AuthorizationAdmin": "88421113",
-  "ApplicationEndpoint": "http://localhost/AuthorizationDev",
-  "ElasticSearchSettings": {
-    "Scheme": "http",
-    "Server": "localhost",
-    "Port": "9200",
-    "Username": "",
-    "Password": ""
-  },
-  "IdentityServerConfidentialClientSettings": {
-    "Authority": "http://localhost/identity",
-    "ClientId": "authorization-api",
-    "ClientSecret": "secret",
-    "Scopes": [
-      "fabric/authorization.read",
-      "fabric/authorization.write",
-      "fabric/authorization.manageclients"
-    ]
-  },
-  "ApplicationInsights": {
-    "InstrumentationKey": "",
-    "Enabled": false
-  },
-  "HostingOptions": {
-    "UseIis": "false"
-  },
-  "EncryptionCertificateSettings": {
-    "EncryptionCertificateThumbprint": ""
-  },
-  "DefaultPropertySettings": {
-    "GroupSource": "Directory",
-    "DualStoreEDWAdminPermissions": "true",
-    "IdentityProvider": "Windows"
-  },
-  "ConnectionStrings": {
-    "AuthorizationDatabase": "Server=localhost;Database=Authorization;Trusted_Connection=True;MultipleActiveResultSets=true",
-    "EDWAdminDatabase": "Server=localhost;Database=EDWAdmin;Trusted_Connection=True;MultipleActiveResultSets=true"
-  },
-  "EntityFrameworkSettings": {
-    "MinimumLogLevel": "Warning"
-  },
-  "DiscoveryServiceSettings": {
-    "AccessControlToken": "DISCOVERY_SERVICE_ROOT",
-    "UseDiscovery": false,
-    "Endpoint": "http://localhost/DiscoveryService/v1",
-    "IdentityServiceToken": "IDENTITY_SERVICE_ROOT"
-  },
-  "IdentityProviderSearchSettings": {
-    "Endpoint": "http://localhost/IdentityProviderSearchService/v1",
-    "Scopes": [ "fabric/idprovider.searchusers" ]
-  },
-  "MigrateDuplicateGroups": true,
-  "MigrateGroupSource": true,
-  "MigrateGroupIdentityProvider": true
+    "ClientName": "hc",
+    "StorageProvider": "sqlserver",
+    "AuthorizationAdmin": "88421113",
+    "ApplicationEndpoint": "http://localhost:5004/",
+    "ElasticSearchSettings": {
+        "Scheme": "http",
+        "Server": "localhost",
+        "Port": "9200",
+        "Username": "",
+        "Password": ""
+    },
+    "IdentityServerConfidentialClientSettings": {
+        "Authority": "http://localhost/identity",
+        "ClientId": "authorization-api",
+        "ClientSecret": "secret",
+        "Scopes": [
+            "fabric/authorization.read",
+            "fabric/authorization.write",
+            "fabric/authorization.manageclients"
+        ]
+    },
+    "ApplicationInsights": {
+        "InstrumentationKey": "",
+        "Enabled": false
+    },
+    "HostingOptions": {
+        "UseIis": "false"
+    },
+    "EncryptionCertificateSettings": {
+        "EncryptionCertificateThumbprint": ""
+    },
+    "DefaultPropertySettings": {
+        "GroupSource": "Directory",
+        "DualStoreEDWAdminPermissions": "true",
+        "IdentityProvider": "Windows"
+    },
+    "ConnectionStrings": {
+        "AuthorizationDatabase": "Server=localhost;Database=Authorization;Trusted_Connection=True;MultipleActiveResultSets=true",
+        "EDWAdminDatabase": "Server=localhost;Database=EDWAdmin;Trusted_Connection=True;MultipleActiveResultSets=true"
+    },
+    "EntityFrameworkSettings": {
+        "MinimumLogLevel": "Warning"
+    },
+    "DiscoveryServiceSettings": {
+        "UseOAuth2Authentication": true,
+        "AccessControlToken": "DISCOVERY_SERVICE_ROOT",
+        "IdentityServiceToken": "IDENTITY_SERVICE_ROOT",
+        "AccessControlUIToken": "ACCESSCONTROL_SERVICE_ROOT",
+        "UseDiscovery": false,
+        "Endpoint": "http://localhost/DiscoveryService/v1/"
+    },
+    "IdentityProviderSearchSettings": {
+        "Endpoint": "http://localhost/IdentityProviderSearchService/v1",
+        "Scopes": [ "fabric/idprovider.searchusers" ]
+    },
+    "MigrateDuplicateGroups": true,
+    "MigrateGroupSource": true,
+    "MigrateGroupIdentityProvider": true
 }

--- a/Fabric.Authorization.API/appsettings.json
+++ b/Fabric.Authorization.API/appsettings.json
@@ -2,7 +2,7 @@
     "ClientName": "hc",
     "StorageProvider": "sqlserver",
     "AuthorizationAdmin": "88421113",
-    "ApplicationEndpoint": "http://localhost:5004/",
+    "ApplicationEndpoint": "http://localhost/AuthorizationDev/",
     "ElasticSearchSettings": {
         "Scheme": "http",
         "Server": "localhost",
@@ -44,7 +44,7 @@
     },
     "DiscoveryServiceSettings": {
         "UseOAuth2Authentication": true,
-        "AccessControlToken": "DISCOVERY_SERVICE_ROOT",
+        "DiscoveryServiceToken": "DISCOVERY_SERVICE_ROOT",
         "IdentityServiceToken": "IDENTITY_SERVICE_ROOT",
         "AccessControlUIToken": "ACCESSCONTROL_SERVICE_ROOT",
         "UseDiscovery": false,

--- a/Fabric.Authorization.API/web.config
+++ b/Fabric.Authorization.API/web.config
@@ -5,8 +5,7 @@
       <authentication>
         <anonymousAuthentication enabled="true" />
       </authentication>
-      <requestFiltering allowDoubleEscaping="true">
-      </requestFiltering>
+      <requestFiltering allowDoubleEscaping="true"></requestFiltering>
     </security>
     <modules>
       <remove name="WebDAVModule" />
@@ -26,7 +25,7 @@
       <remove name="WebDAV" />
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="dotnet" arguments=".\Fabric.Authorization.API.dll" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout" >
+    <aspNetCore processPath="bin\IISSupport\VSIISExeLauncher.exe" arguments="-argFile IISExeLauncherArgs.txt" stdoutLogEnabled="true" stdoutLogFile=".\logs\stdout">
       <environmentVariables>
         <clear />
         <environmentVariable name="HostingOptions__UseIis" value="true" />

--- a/Fabric.Authorization.AccessControl/src/app/services/global/config.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/config.service.ts
@@ -17,4 +17,8 @@ export class ConfigService {
   public getIdentityServiceRoot(): Observable<string> {
     return of(getWindow().identityServiceRoot);
   }
+
+  public getAccessControlServiceRoot(): Observable<string> {
+    return of(getWindow().accessControlServiceRoot);
+  }
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
@@ -1,7 +1,7 @@
-import { map, mergeMap, switchMap } from 'rxjs/operators';
+import { map, mergeMap, switchMap, tap, every } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable, of, forkJoin } from 'rxjs';
 
 import { ConfigService } from './config.service';
 import { OData } from './odata';
@@ -44,17 +44,100 @@ export class ServicesService {
         }
     ];
 
-    constructor(private http: HttpClient, private configService: ConfigService) {}
+    constructor(private http: HttpClient, private configService: ConfigService) { }
 
-    public initialize(): Observable<string> {
+    public initialize() {
+
+    }
+
+    public getIdentityAndAccessControlUrl(): Observable<string[]> {
+        return this.isOAuthAuthenticationEnabled.pipe(
+            switchMap(isEnabled => {
+              if(isEnabled) {
+                // if OAuth, we get identity and access control up front
+                return forkJoin(this.identityServiceEndpoint, this.accessControlEndpoint)
+              } else {
+                // If Windows Auth, we have discovery up front and have to build
+                // out the service urls from discovery
+                return this.buildServiceMaps().toPromise().then(identityUrl => {
+                        return this.accessControlEndpoint.toPromise().then(accessControlUrl => {
+                            return [identityUrl, accessControlUrl]
+                        })
+                    })
+              }
+            })
+        )
+    }
+
+    private baseDiscoveryServiceUrl: string;
+    get discoveryServiceEndpoint(): Observable<string> {
+        if (this.baseDiscoveryServiceUrl === undefined) {
+            // if discovery service url is pushed to the website by the window.location, then use that
+            // if we get identity service url instead, then visit this website, grab the discovery_uri from 
+            // identity instead.
+            return this.configService.getDiscoveryServiceRoot()
+                .pipe(switchMap(url => url === '' ? this.discoveryServiceUrlFromIdentity : of(url)),
+                    map(url => this.trimRightChar(url, '/')),
+                    tap(url => this.baseDiscoveryServiceUrl = url));
+        }
+
+        return of(this.baseDiscoveryServiceUrl);
+    }
+
+    get isOAuthAuthenticationEnabled(): Observable<boolean> {
+        return this.configService.getDiscoveryServiceRoot().pipe(
+            every(url => url === '')
+        )
+    }
+
+    get discoveryServiceUrlFromIdentity(): Observable<string> {
+        return this.configService.getIdentityServiceRoot()
+            .pipe(map((url) => `${url}/.well-known/openid-configuration`),
+                switchMap((url) => this.http.get(url)),
+                map((response: any) => response.discovery_uri));
+    }
+
+    get identityServiceEndpoint(): Observable<string> {
+        var serviceUrl = this.services.find(s => s.name === 'IdentityService').url;
+        return this.configService.getIdentityServiceRoot()
+            .pipe(map(url => url === '' ? serviceUrl : url))
+    }
+
+    get authorizationServiceEndpoint(): string {
+        return this.services.find(s => s.name === 'AuthorizationService').url;
+    }
+
+    get identityProviderSearchServiceEndpoint(): string {
+        return this.services.find(s => s.name === 'IdentityProviderSearchService').url;
+    }
+
+    get accessControlEndpoint(): Observable<string> {
+        const accessControlUrl = this.services.find(s => s.name === 'AccessControl').url;
+        if (accessControlUrl == undefined || accessControlUrl == '') {
+            return this.configService.getAccessControlServiceRoot();
+        }
+
+        return of(accessControlUrl);
+    }
+
+    public needsAuthToken(url: string) {
+        // by getting just the path name, this strips out the host
+        // and any query string parameters that will affect the results.
+        // it was needed because discovery service urls have other services in them
+        const urlLowerCase = this.parseUrl(url.toLowerCase()).pathname;
+        // find the service with this url
+        // if you cannot, then find the best match
+        const service: IService = this.services.find(s => urlLowerCase.includes(s.name.toLowerCase()));
+        const targetService: IService = service ? service : this.findUrlBestMatch(url);
+
+        // take that service, see if it requires Authentication Token
+        return targetService ? targetService.requireAuthToken : false;
+    }
+
+    private buildServiceMaps(): Observable<string> {
         return this.discoveryServiceEndpoint.pipe(
-            mergeMap(discoveryServiceRoot => {
-                const url: string =
-                    `${discoveryServiceRoot}/Services?$filter=` +
-                    this.services.map(service => `ServiceName eq \'${service.name}\'`).join(' or ') +
-                    `&$select=ServiceUrl,Version,ServiceName`;
-                return this.http.get<OData.IArray<IDiscoveryService>>(url, {withCredentials: true});
-            }),
+            map(discoveryUrl => `${discoveryUrl}/Services?$filter=` + this.buildServiceFilter() + `&$select=ServiceUrl,Version,ServiceName`),
+            mergeMap(discoveryUrl => this.http.get<OData.IArray<IDiscoveryService>>(discoveryUrl, { withCredentials: true })),
             map(response => {
                 for (const service of this.services) {
                     const targetService: IDiscoveryService = response.value.find(
@@ -68,85 +151,54 @@ export class ServicesService {
                     } else {
                         service.url = targetService.ServiceUrl;
                     }
-                    
-                    return this.services.find(s => s.name === 'IdentityService').url;
                 }
+                
+                return this.services.find(s => s.name === 'IdentityService').url;
             })
         );
     }
 
-    private baseDiscoveryServiceUrl : string;
-    get discoveryServiceEndpoint(): Observable<string> {
-        if(this.baseDiscoveryServiceUrl === undefined) {
-            const identityDiscoveryUrlObservable: Observable<string> = this.configService.getIdentityServiceRoot()
-                .pipe( map((url) => `${url}/.well-known/openid-configuration`) )
-                .pipe( switchMap((url) => this.http.get(url)) )
-                .pipe( switchMap((response:any) => {
-                    this.baseDiscoveryServiceUrl = response.discovery_uri; 
-                    return response.discovery_uri; 
-                }));
+    private findUrlBestMatch(url: string) {
+        var serviceUrlMatch = "";
+        this.services.forEach(element => {
+            if (element.url) {
+                var result = url.toLowerCase().includes(element.url.toLowerCase());
 
-            // if discovery service url is pushed to the website by the window.location, then use that
-            // if we get identity service url instead, then visit this website, grab the discovery_uri from 
-            // identity instead.
-            return this.configService.getDiscoveryServiceRoot()
-                       .pipe( switchMap( url => { 
-                           if(url === '') { 
-                               return identityDiscoveryUrlObservable; 
-                            } 
-                            
-                            return of(url);
-                        }));
+                if (result) {
+                    if (element.url.length > serviceUrlMatch.length) {
+                        serviceUrlMatch = element.url.toLowerCase();
+                    }
+                }
+            }
+        });
 
-            return 
+        var matchedService = this.services.find(s => s.url && s.url.toLowerCase() === serviceUrlMatch);
+        const serviceItem: IService = matchedService;
+        return serviceItem;
+    }
+
+    private trimRightChar(characters, char) {
+        var i = 0;
+        while (characters[characters.length - 1 - i] === char)
+            i++
+
+        return characters.substring(0, characters.length - i);
+    }
+
+    private buildServiceFilter(): string {
+        return this.services.map(service => `ServiceName eq \'${service.name}\'`).join(' or ');
+    }
+
+    private parseUrl(url) {
+        var location = document.createElement("a")
+        location.href = url
+        // IE doesn't populate all link properties when setting .href with a relative URL,
+        // however .href will return an absolute URL which then can be used on itself
+        // to populate these additional fields.
+        if (location.host == "") {
+            location.href = location.href;
         }
 
-        return of(this.baseDiscoveryServiceUrl);
-    }
-
-    get identityServiceEndpoint(): string {
-        return this.services.find(s => s.name === 'IdentityService').url;
-    }
-
-    get authorizationServiceEndpoint(): string {
-        return this.services.find(s => s.name === 'AuthorizationService').url;
-    }
-
-    get identityProviderSearchServiceEndpoint(): string {
-        return this.services.find(s => s.name === 'IdentityProviderSearchService').url;
-    }
-
-    get accessControlEndpoint(): Observable<string> {
-        const accessControlUrl = this.services.find(s => s.name === 'AccessControl').url;
-        if(accessControlUrl == undefined || accessControlUrl == '')
-        {
-            return this.configService.getAccessControlServiceRoot();
-        }
-
-        return of(accessControlUrl);
-    }
-
-    public needsAuthToken(url: string) {
-        const urlLowerCase = url.toLowerCase();
-        const targetService: IService = this.services.find(s => urlLowerCase.includes(s.name.toLowerCase())) ? this.services.find(s => urlLowerCase.includes(s.name.toLowerCase())) : this.findUrlBestMatch(this.services, url);
-        return targetService ? targetService.requireAuthToken : false;
-    }
-
-    public findUrlBestMatch(services: IService[], url: string)
-    {
-       var serviceUrlMatch = "";
-       services.forEach(element => {
-        var result = url.toLowerCase().includes(element.url.toLowerCase());
-        if (result)
-        {
-          if (element.url.length > serviceUrlMatch.length)
-          {
-            serviceUrlMatch = element.url.toLowerCase();
-          }
-        }
-       });
-       var matchedService = services.find(s => s.url.toLowerCase() === serviceUrlMatch);
-       const serviceItem: IService = matchedService;
-       return serviceItem;
+        return location
     }
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/interceptors/fabric-http-fake-discovery-interceptor.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/interceptors/fabric-http-fake-discovery-interceptor.service.ts
@@ -21,6 +21,10 @@ export class FabricHttpFakeDiscoveryInterceptorService implements HttpIntercepto
   ): Observable<HttpEvent<any>> {
     if(req.url.includes('DiscoveryService/v1/Services?$filter=ServiceName')){
         this.configService.getIdentityServiceRoot().subscribe(url => {
+          if(url === '') { // this can happen if windows auth is on
+            url = "http://localhost/identity"
+          }
+
           this.responseBody = {
             "@odata.context":"http://localhost/DiscoveryService/v1/$metadata#Services(ServiceUrl,Version,ServiceName)","value":[
               {

--- a/Fabric.Authorization.AccessControl/src/index.html
+++ b/Fabric.Authorization.AccessControl/src/index.html
@@ -9,7 +9,9 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <script>
     window.discoveryServiceRoot = "DISCOVERY_SERVICE_ROOT";
+
     window.identityServiceRoot = "IDENTITY_SERVICE_ROOT";
+    window.accessControlServiceRoot = "ACCESSCONTROL_SERVICE_ROOT";
   </script>
 </head>
 <body>

--- a/Fabric.Authorization.FunctionalTests/package-lock.json
+++ b/Fabric.Authorization.FunctionalTests/package-lock.json
@@ -328,7 +328,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
           "requires": {
             "ms": "2.0.0"
           }
@@ -906,7 +906,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "requires": {
         "glob": "^7.0.5"
       }
@@ -1078,7 +1078,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"


### PR DESCRIPTION
This is the first PR to test the waters on this approach.

First, if discovery service root is populated, it will revert to the old way.  I will be adding the feature flag to authorization service because that seems to be the better way to do it.  If I should add the feature flag explicitly in Access Control, let me know.

Second, because we got Access Control's url from discovery and we need it to get an access token, I am saying authorization must push both Identity and Access Control's url.

If everything looks good i will fix up the code some more, add in authorization code changes and add tests.