### PR TITLE
Added code to only send group delete if actual groups change

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-auth-group.service.ts
@@ -251,6 +251,11 @@ export class FabricAuthGroupService extends FabricBaseService {
     identityProvider?: string,
     tenantId?: string
   ): Observable<IGroup> {
+
+    if (!childGroups || childGroups.length === 0) {
+      return of(undefined);
+    }
+
     const url = this.replaceGroupNameSegment(FabricAuthGroupService.childGroupsApiUrl, groupName);
 
     return this.httpClient.request<IGroup>(


### PR DESCRIPTION
Added logic to not send the child group deletion if no groups changed.  To fully "fix" the issue we'll also want to add some notes that if you're removing yourself from the group that is the only operation you should perform - you shouldn't attempt to remove other users, groups or roles.