### PR TITLE
Display error page when cookies are not enabled

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/no-cookies.app.module.ts
+++ b/Fabric.Authorization.AccessControl/src/app/no-cookies.app.module.ts
@@ -1,0 +1,32 @@
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ButtonModule, ProgressIndicatorsModule, NavbarModule, PopoverModule,
+  AppSwitcherModule, IconModule } from '@healthcatalyst/cashmere';
+
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { NoCookiesComponent } from './no-cookies/no-cookies.component';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+
+@NgModule({
+  imports: [
+    RouterModule.forRoot([])
+  ],
+  exports: [RouterModule]
+})
+export class NoCookiesAppRoutingModule {}
+
+@NgModule({
+  declarations: [NoCookiesComponent],
+  imports: [NoCookiesAppRoutingModule, BrowserModule, BrowserAnimationsModule,
+    ButtonModule, ProgressIndicatorsModule, NavbarModule, PopoverModule,
+    AppSwitcherModule, IconModule],
+  bootstrap: [NoCookiesComponent]
+})
+export class NoCookiesAppModule {}
+
+export function bootstrapNoCookiesAppModule() {
+  platformBrowserDynamic()
+    .bootstrapModule(NoCookiesAppModule)
+    .catch(err => console.log(err));
+}

--- a/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.html
+++ b/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.html
@@ -1,0 +1,41 @@
+<hc-navbar appIcon="./assets/AccessControlLogo.svg" brandIcon="./assets/TriFlame.svg" user="" homeUri="access-control"  [fixedTop]="false">
+  <hc-navbar-icon>
+      <hc-icon fontSet="fa" fontIcon="fa-question-circle-o" [hcPopover]="options" popperPlacement="bottom"></hc-icon>
+  </hc-navbar-icon>
+</hc-navbar>
+
+<hc-popover-content #options>
+  <ul class="list-options">
+      <li>
+          <a href="https://www.healthcatalyst.com/" target="_blank">Health Catalyst</a>
+      </li>
+      <li>
+          <a href="https://community.healthcatalyst.com/" target="_blank">Health Catalyst Community</a>
+      </li>
+  </ul>
+</hc-popover-content>
+
+<div class="error-container">
+    <div class="error-tile">
+      <div class="content-column">
+          <div class="error-img"></div>
+      </div>
+      <div class="content-column">
+          <div class="error-header-string">Error</div>
+          <div class="error-message-light">
+              Your browser is currently set to block cookies. You need to allow cookies
+              to use this service.
+          </div>
+          <div><br/></div>
+          <div class="error-message-light">
+              Cookies are small text files stored on your computer that tell us when you're
+              signed in. To learn how to allow cookies, check the online help in your
+              web browser.
+          </div>
+      </div>
+      <hr>
+      <div class="logged-out-footer">
+        <div class="error-button" (click)="reload()">Refresh</div>
+      </div>
+    </div>
+  </div>

--- a/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.scss
+++ b/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.scss
@@ -1,0 +1,10 @@
+@import "~@healthcatalyst/cashmere/scss/colors";
+
+.error-container{
+    margin: 100px auto;
+    .logged-out-footer{
+        width: 215px;
+        padding-bottom: 20px;
+        margin: 0 auto;
+    }
+}

--- a/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {RouterTestingModule} from '@angular/router/testing';
+import { NavbarModule, PopoverModule, IconModule } from '@healthcatalyst/cashmere';
+
+import { NoCookiesComponent } from './no-cookies.component';
+
+describe('NoCookiesComponent', () => {
+  let component: NoCookiesComponent;
+  let fixture: ComponentFixture<NoCookiesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NoCookiesComponent ],
+      imports: [RouterTestingModule, NavbarModule, PopoverModule, IconModule]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NoCookiesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.ts
@@ -1,0 +1,26 @@
+import { Component, OnInit } from '@angular/core';
+import { BrowserRequirementsService } from '../services/browser-requirements.service';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './no-cookies.component.html',
+  styleUrls: ['./no-cookies.component.scss']
+})
+export class NoCookiesComponent implements OnInit {
+
+  constructor(
+    private browserRequirements: BrowserRequirementsService
+  ) { }
+
+  ngOnInit() {
+    setInterval(() => {
+      if (this.browserRequirements.cookiesEnabled()) {
+        window.location.reload();
+      }
+    }, 1000);
+  }
+
+  reload() {
+    window.location.reload();
+  }
+}

--- a/Fabric.Authorization.AccessControl/src/app/services/browser-requirements.service.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/browser-requirements.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { BrowserRequirementsService } from './browser-requirements.service';
+
+describe('BrowserRequirementsService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [BrowserRequirementsService]
+    });
+  });
+
+  it('should be created', inject([BrowserRequirementsService], (service: BrowserRequirementsService) => {
+    expect(service).toBeTruthy();
+  }));
+
+  it('should return true', inject([BrowserRequirementsService], (service: BrowserRequirementsService) => {
+    expect(service.cookiesEnabled()).toBeTruthy();
+  }));
+});

--- a/Fabric.Authorization.AccessControl/src/app/services/browser-requirements.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/browser-requirements.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class BrowserRequirementsService {
+
+  constructor() { }
+
+  cookiesEnabled(): boolean {
+    const userAgent = window.navigator.userAgent;
+    if (!(userAgent.indexOf('MSIE ') > -1 || userAgent.indexOf('Trident') > -1) &&
+        typeof navigator.cookieEnabled !== 'undefined' && navigator.cookieEnabled) {
+      return true;
+    }
+    if (!document.cookie || document.cookie === '') {
+      const originalCookieValue = document.cookie;
+      document.cookie = 'testCookie';
+      const testCookieMatched = (document.cookie.indexOf('testCookie') !== -1);
+      document.cookie = originalCookieValue;
+      return testCookieMatched;
+    }
+    return false;
+  }
+}

--- a/Fabric.Authorization.AccessControl/src/main.ts
+++ b/Fabric.Authorization.AccessControl/src/main.ts
@@ -4,10 +4,18 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
+import { BrowserRequirementsService } from './app/services/browser-requirements.service';
+import { bootstrapNoCookiesAppModule } from './app/no-cookies.app.module';
+
 if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+const browserRequirementsService = new BrowserRequirementsService();
+if (browserRequirementsService.cookiesEnabled()) {
+  platformBrowserDynamic()
+    .bootstrapModule(AppModule)
+    .catch(err => console.log(err));
+} else {
+  bootstrapNoCookiesAppModule();
+}


### PR DESCRIPTION
This PR pertains to bug [162684](https://healthcatalyst.visualstudio.com/CAP/_workitems/edit/162684). 

Within `main.ts` use the new `BrowserRequirementsService`'s `cookiesEnabled` method to test whether or not cookies are enabled. If they are not bootstrap the new `no-cookies.app` instead of the main application. The main application itself requires cookies along with local and session storage (as controlled by browsers cookies settings). By creating the `no-cookies.app` we can provide the user with an appropriately styled error page. The error page will retest for cookies and reload the application when cookie support is re-enabled.