### PR TITLE
Discovery Url for Windows Auth needs false

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
@@ -54,6 +54,7 @@ export class ServicesService {
     public getIdentityAndAccessControlUrl(): Observable<UrlResponse> {
         return this.isOAuthAuthenticationEnabled.pipe(
             switchMap(isEnabled => {
+              this.services.find(s => s.name === 'DiscoveryService').requireAuthToken = isEnabled              
               if(isEnabled) {
                 // if OAuth, we get identity and access control up front
                 return forkJoin(this.identityServiceEndpoint, this.accessControlEndpoint)


### PR DESCRIPTION
With the mock, this was missed.  Basically if the service is using windows auth, it will not require an auth token.  This will be false.  If the discovery service is using OAuth, then it will be true.