### PR TITLE
moved the buildServiceMaps back into the initializer to avoid weird bugs

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/services/access-control-config.service.mock.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/access-control-config.service.mock.ts
@@ -12,8 +12,4 @@ export class MockAccessControlConfigService implements IAccessControlConfigServi
     fabricExternalIdpSearchApiUrl = 'idpss';
     dataChanged = new Subject<IDataChangedEventArgs>();
     errorRaised: Subject<Exception>;
-
-    getBaseUrls(): Observable<string[]> {
-        return of([])
-    }
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/access-control-config.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/access-control-config.service.ts
@@ -11,5 +11,4 @@ export interface IAccessControlConfigService {
   fabricExternalIdpSearchApiUrl: string;
   dataChanged: Subject<IDataChangedEventArgs>;
   errorRaised: Subject<Exception>;
-  getBaseUrls(): Observable<string[]>
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/fabric-base.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/fabric-base.service.ts
@@ -9,6 +9,6 @@ export class FabricBaseService {
     protected httpClient: HttpClient,
     @Inject('IAccessControlConfigService') protected accessControlConfigService: IAccessControlConfigService
   ) {
-    accessControlConfigService.getBaseUrls().toPromise()
+    
   }
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/global/client-access-control-config.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/client-access-control-config.service.ts
@@ -20,16 +20,9 @@ export class ClientAccessControlConfigService implements IAccessControlConfigSer
     this.errorRaised.subscribe((eventArgs: Exception) => {
       console.log(`error: ${JSON.stringify(eventArgs)}`);
     });
-  }
 
-  public getBaseUrls(): Observable<string[]> {
-    return this.servicesService.buildServiceMaps().pipe(
-      switchMap(url => {
-        this.fabricAuthApiUrl = this.servicesService.authorizationServiceEndpoint
-        this.fabricExternalIdpSearchApiUrl = this.servicesService.identityProviderSearchServiceEndpoint
-        return [this.fabricAuthApiUrl, this.fabricExternalIdpSearchApiUrl]
-      })
-    )
+    this.fabricAuthApiUrl = this.servicesService.authorizationServiceEndpoint
+    this.fabricExternalIdpSearchApiUrl = this.servicesService.identityProviderSearchServiceEndpoint
   }
 
   clientId = '';

--- a/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
@@ -48,7 +48,7 @@ export class ServicesService {
     constructor(private http: HttpClient, private configService: ConfigService) { }
 
     public initialize() {
-
+        this.buildServiceMaps()
     }
 
     public getIdentityAndAccessControlUrl(): Observable<UrlResponse> {
@@ -137,7 +137,7 @@ export class ServicesService {
         return targetService ? targetService.requireAuthToken : false;
     }
 
-    public buildServiceMaps(): Observable<string> {
+    private buildServiceMaps(): Observable<string> {
         return this.discoveryServiceEndpoint.pipe(
             map(discoveryUrl => `${discoveryUrl}/Services?$filter=` + this.buildServiceFilter() + `&$select=ServiceUrl,Version,ServiceName`),
             mergeMap(discoveryUrl => this.http.get<OData.IArray<IDiscoveryService>>(discoveryUrl, { withCredentials: true })),
@@ -181,9 +181,13 @@ export class ServicesService {
     }
 
     private trimRightChar(characters, char) {
+        if (characters === undefined || characters === null) {
+            return characters;
+        }
+
         var i = 0;
         while (characters[characters.length - 1 - i] === char)
-            i++
+            i++;
 
         return characters.substring(0, characters.length - i);
     }


### PR DESCRIPTION
The previous code was causing a race condition as well as calling build service maps every time a service was created.  This would call discovery service too many times.  We found it was only needed to be called from the initializer.