### PR TITLE
Remove progress bar when downloading assets during installation

### DIFF
--- a/Fabric.Authorization.API/scripts/AzureAD-Groups-Migration.ps1
+++ b/Fabric.Authorization.API/scripts/AzureAD-Groups-Migration.ps1
@@ -26,7 +26,7 @@ Import-Module ActiveDirectory
 $fabricInstallUtilities = "$PSScriptRoot\Fabric-Install-Utilities.psm1"
 if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -NoCache -OutFile $fabricInstallUtilities
 }
 Import-Module -Name $fabricInstallUtilities -Force
 

--- a/Fabric.Authorization.API/scripts/AzureAD-Users-Migration.ps1
+++ b/Fabric.Authorization.API/scripts/AzureAD-Users-Migration.ps1
@@ -45,7 +45,7 @@ Import-Module -Name .\Install-Authorization-Utilities.psm1 -Force
 $identityInstallUtilities = ".\Install-Identity-Utilities.psm1"
 if (!(Test-Path $identityInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find identity install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/Fabric.Identity/master/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $identityInstallUtilities
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/Fabric.Identity/master/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1 -NoCache -OutFile $identityInstallUtilities
 }
 Import-Module -Name $identityInstallUtilities -Force
 
@@ -53,7 +53,7 @@ Import-Module -Name $identityInstallUtilities -Force
 $fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
 if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -NoCache -OutFile $fabricInstallUtilities
 }
 Import-Module -Name $fabricInstallUtilities -Force
 $credentials = @{}

--- a/Fabric.Authorization.API/scripts/AzureAD-Utilities.psm1
+++ b/Fabric.Authorization.API/scripts/AzureAD-Utilities.psm1
@@ -1,5 +1,5 @@
 # Import Dos Install Utilities
-$minVersion = [System.Version]::new(1, 0, 234, 0)
+$minVersion = [System.Version]::new(1, 0, 248, 0)
 try {
     Get-InstalledModule -Name DosInstallUtilities -MinimumVersion $minVersion -ErrorAction Stop
 } catch {
@@ -12,7 +12,7 @@ Import-Module -Name DosInstallUtilities -Force
 $fabricInstallUtilities = "$PSScriptRoot\Fabric-Install-Utilities.psm1"
 if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -NoCache -OutFile $fabricInstallUtilities
 }
 Import-Module -Name $fabricInstallUtilities -Force
 

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.psm1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.psm1
@@ -1,13 +1,5 @@
-# Import Fabric Install Utilities
-$fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
-if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
-    Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
-}
-Import-Module -Name $fabricInstallUtilities -Force
-
 # Import Dos Install Utilities
-$minVersion = [System.Version]::new(1, 0, 234, 0)
+$minVersion = [System.Version]::new(1, 0, 248, 0)
 try {
     Get-InstalledModule -Name DosInstallUtilities -MinimumVersion $minVersion -ErrorAction Stop
 } catch {
@@ -15,6 +7,14 @@ try {
     Install-Module DosInstallUtilities -Scope CurrentUser -MinimumVersion $minVersion -Force
 }
 Import-Module -Name DosInstallUtilities -MinimumVersion $minVersion -Force
+
+# Import Fabric Install Utilities
+$fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
+if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
+    Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -NoCache -OutFile $fabricInstallUtilities
+}
+Import-Module -Name $fabricInstallUtilities -Force
 
 Add-Type -AssemblyName System.Web
 
@@ -788,7 +788,7 @@ function Install-UrlRewriteIfNeeded
     {    
         try {
             Write-DosMessage -Level "Information" -Message "IIS URL Rewrite Module 2 version $version not installed...installing version $version"        
-            Invoke-WebRequest -Uri $downloadUrl -OutFile $env:Temp\rewrite_amd64_en-US.msi
+            Get-WebRequestDownload -Uri $downloadUrl -OutFile $env:Temp\rewrite_amd64_en-US.msi
             Start-Process msiexec.exe -Wait -ArgumentList "/i $($env:Temp)\rewrite_amd64_en-US.msi /qn"
             Write-DosMessage -Level "Information" -Message "IIS URL Rewrite Module 2 installed successfully."
         }

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.tests.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.tests.ps1
@@ -798,7 +798,7 @@ Describe 'Install-UrlRewriteIfNeeded' -Tag 'Unit'{
             It 'Installs url rewrite if minimum version is not present'{
                 # Arrange
                 Mock Test-Prerequisite { return $false}
-                Mock Invoke-WebRequest {}
+                Mock Get-WebRequestDownload {}
                 Mock Start-Process {}
                 Mock Remove-Item {}
 
@@ -806,13 +806,13 @@ Describe 'Install-UrlRewriteIfNeeded' -Tag 'Unit'{
                 Install-UrlRewriteIfNeeded -version "1.1.1.1" -downloadUrl "http://host.domain.local/url-rewrite.msi"
 
                 # Assert
-                Assert-MockCalled Invoke-WebRequest -Times 1
+                Assert-MockCalled Get-WebRequestDownload -Times 1
                 Assert-MockCalled Start-Process -Times 1
             }
             It 'Throws an exception when Start-Process fails'{
                 # Arrange
                 Mock Test-Prerequisite { return $false}
-                Mock Invoke-WebRequest {}
+                Mock Get-WebRequestDownload {}
                 Mock Start-Process {throw "bad stuff happened"}
                 Mock Remove-Item {}
 
@@ -822,7 +822,7 @@ Describe 'Install-UrlRewriteIfNeeded' -Tag 'Unit'{
             It 'Should warn when we cannot clean up the install files, but not throw an error'{
                 # Arrange
                 Mock Test-Prerequisite { return $false}
-                Mock Invoke-WebRequest {}
+                Mock Get-WebRequestDownload {}
                 Mock Start-Process {}
                 Mock Remove-Item { throw "bad stuff happened"}
                 Mock Write-DosMessage {}
@@ -838,7 +838,7 @@ Describe 'Install-UrlRewriteIfNeeded' -Tag 'Unit'{
             It 'Does not install url rewrite if minimum version is present'{
                 # Arrange
                 Mock Test-Prerequisite { return $true}
-                Mock Invoke-WebRequest {}
+                Mock Get-WebRequestDownload {}
                 Mock Start-Process {}
                 Mock Write-DosMessage {}
 
@@ -846,7 +846,7 @@ Describe 'Install-UrlRewriteIfNeeded' -Tag 'Unit'{
                 Install-UrlRewriteIfNeeded -version "1.1.1.1" -downloadUrl "http://host.domain.local/url-rewrite.msi"
 
                 # Assert
-                Assert-MockCalled Invoke-WebRequest -Times 0
+                Assert-MockCalled Get-WebRequestDownload -Times 0
                 Assert-MockCalled Start-Process -Times 0
                 Assert-MockCalled Write-DosMessage -Times 1
             }

--- a/Fabric.Authorization.API/scripts/Install-Authorization.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization.ps1
@@ -24,7 +24,7 @@ Import-Module -Name .\Install-Authorization-Utilities.psm1 -Force
 $identityInstallUtilities = ".\Install-Identity-Utilities.psm1"
 if (!(Test-Path $identityInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find identity install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/Fabric.Identity/master/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $identityInstallUtilities
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/Fabric.Identity/master/Fabric.Identity.API/scripts/Install-Identity-Utilities.psm1 -NoCache -OutFile $identityInstallUtilities
 }
 Import-Module -Name $identityInstallUtilities -Force
 
@@ -32,7 +32,7 @@ Import-Module -Name $identityInstallUtilities -Force
 $fabricInstallUtilities = ".\Fabric-Install-Utilities.psm1"
 if (!(Test-Path $fabricInstallUtilities -PathType Leaf)) {
     Write-DosMessage -Level "Warning" -Message "Could not find fabric install utilities. Manually downloading and installing"
-    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -Headers @{"Cache-Control" = "no-cache"} -OutFile $fabricInstallUtilities
+    Get-WebRequestDownload -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -NoCache -OutFile $fabricInstallUtilities
 }
 Import-Module -Name $fabricInstallUtilities -Force
 


### PR DESCRIPTION
Using the newly introduced "Get-WebRequestDownload" function in DosInstallUtilities to remove the progress bar when downloading assets for installation.