### PR TITLE
Changed the way the component was reloaded to eliminate tests running multiple times

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/no-cookies/no-cookies.component.ts
@@ -15,7 +15,7 @@ export class NoCookiesComponent implements OnInit {
   ngOnInit() {
     setInterval(() => {
       if (this.browserRequirements.cookiesEnabled()) {
-        window.location.reload();
+        this.ngOnInit();
       }
     }, 1000);
   }


### PR DESCRIPTION
Somehow using window.location.reload() causes the angular tests to be ran multiple times. Changing to this.ngOnInit eliminated that when I ran them locally.