### PR TITLE
Fixing issue where user removes self from group

### DIFF
--- a/Fabric.Authorization.API/Dockerfile
+++ b/Fabric.Authorization.API/Dockerfile
@@ -3,7 +3,11 @@ ARG source
 WORKDIR /app
 EXPOSE 5004
 
-RUN apt-get update -y && \
+RUN echo "deb [check-valid-until=no] http://cdn-fastly.deb.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list
+RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
+
+RUN apt-get -o Acquire::Check-Valid-Until=false update -y && \
 	apt-get install -y --no-install-recommends\
 	cron \
 	ldap-utils \

--- a/Fabric.Authorization.API/Dockerfile
+++ b/Fabric.Authorization.API/Dockerfile
@@ -3,23 +3,6 @@ ARG source
 WORKDIR /app
 EXPOSE 5004
 
-RUN echo "deb [check-valid-until=no] http://cdn-fastly.deb.debian.org/debian jessie main" > /etc/apt/sources.list.d/jessie.list
-RUN echo "deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
-RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
-
-RUN apt-get -o Acquire::Check-Valid-Until=false update -y && \
-	apt-get install -y --no-install-recommends\
-	cron \
-	ldap-utils \
-	&& rm -rf /var/lib/apt/lists/*
-
 COPY ${source:-obj/Docker/publish} .
-
-RUN mkdir -p /usr/local/bin \
-	&& mv scripts/update-groups.sh /usr/local/bin/update-groups.sh \
-	&& chmod a+x scripts/setup-crontab.sh \
-	&& chmod a+x /usr/local/bin/update-groups.sh
-
-#RUN	./scripts/setup-crontab.sh
 
 ENTRYPOINT ["dotnet", "Fabric.Authorization.API.dll"]

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.spec.ts
@@ -43,6 +43,7 @@ import { IFabricPrincipal } from '../../../models/fabricPrincipal.model';
 import { FabricAuthEdwAdminService } from '../../../services/fabric-auth-edwadmin.service';
 import { AlertService } from '../../../services/global/alert.service';
 import { Router } from '@angular/router';
+import { MockAuthService } from '../../../services/global/auth.service.mock';
 
 describe('CustomGroupComponent', () => {
   let component: CustomGroupComponent;
@@ -67,7 +68,13 @@ describe('CustomGroupComponent', () => {
           LabelModule,
           CheckboxModule,
           ProgressIndicatorsModule,
-          ToastrModule.forRoot()]
+          ToastrModule.forRoot()],
+        providers: [
+          {
+            provide: 'IAuthService',
+            useClass: MockAuthService
+          }
+         ]
       }).compileComponents();
     })
   );

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
@@ -454,9 +454,9 @@ export class CustomGroupComponent implements OnInit, OnDestroy {
               {
                 if(this.checkIfUserRemovedSelfFromGroup(currentUser, usersToRemove))
                 {
-                  this.currentUserService.resetPermssionCache();
+                  this.currentUserService.resetPermissionCache();
                 }
-              });
+              }).catch(() => console.log('Promise rejected.'));
 
             // get child groups to add/remove
             const childGroupsToAdd = this.associatedGroups
@@ -610,11 +610,11 @@ export class CustomGroupComponent implements OnInit, OnDestroy {
 
   checkIfUserRemovedSelfFromGroup(currentUser: User, removedUsersList: IUser[]): boolean {
     var matched = false;
-    removedUsersList.forEach(removedUser => {
-      if(removedUser.subjectId.toLowerCase == currentUser.profile.sub.toLowerCase) {
-        matched = true;
-      }          
-    });
+    for(let i = 0; i < removedUsersList.length; i++){
+      if(removedUsersList[i].subjectId.toLowerCase() == currentUser.profile.sub.toLowerCase()) {
+        return true;
+      }
+    };
     return matched;
   }
 

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
@@ -611,7 +611,7 @@ export class CustomGroupComponent implements OnInit, OnDestroy {
   checkIfUserRemovedSelfFromGroup(currentUser: User, removedUsersList: IUser[]): boolean {
     var matched = false;
     for(let i = 0; i < removedUsersList.length; i++){
-      if(removedUsersList[i].subjectId.toLowerCase() == currentUser.profile.sub.toLowerCase()) {
+      if(removedUsersList[i].subjectId.toLowerCase() === currentUser.profile.sub.toLowerCase()) {
         return true;
       }
     };

--- a/Fabric.Authorization.AccessControl/src/app/services/current-user.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/current-user.service.ts
@@ -26,7 +26,7 @@ export class CurrentUserService {
     return of(this.permissions);
   }
 
-  resetPermssionCache() {
+  resetPermissionCache() {
     this.lastUpdateTimestamp = 0;
   }
 

--- a/Fabric.Authorization.AccessControl/src/app/services/current-user.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/current-user.service.ts
@@ -25,4 +25,9 @@ export class CurrentUserService {
 
     return of(this.permissions);
   }
+
+  resetPermssionCache() {
+    this.lastUpdateTimestamp = 0;
+  }
+
 }

--- a/Fabric.Authorization.AccessControl/src/app/services/global/auth.service.mock.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/auth.service.mock.ts
@@ -27,6 +27,7 @@ export class MockAuthService implements IAuthService {
 
     getUser(): Promise<User>{
       const user = <User>{};
+      user.profile = {"sub": ''};
       return new Promise((resolve) =>{
         resolve(user);
       });


### PR DESCRIPTION
Fixed the issue when the user removes themselves from the DOS Admin group, if you quickly go back in the group, the permsission cache is still active and you can see an 'Enabled' Save button.