### PR TITLE
Changed from showing subject Id to display name

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.html
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/member-list/member-list.component.html
@@ -1,7 +1,7 @@
 <ng-template #confirmDialog let-close="close" let-dismiss="dismiss" let-data="data">
   <hc-modal>
     <hc-modal-header>Confirm</hc-modal-header>
-    <hc-modal-body>Are you sure you want to remove all {{data.grain}}/{{data.securableItem}} roles from {{data.member.subjectId}}?</hc-modal-body>
+    <hc-modal-body>Are you sure you want to remove all {{data.grain}}/{{data.securableItem}} roles from {{data.member.displayName}}?</hc-modal-body>
     <hc-modal-footer>
       <button hc-button buttonStyle="secondary" (click)="dismiss()"> Cancel </button>
       <button hc-button buttonStyle="primary" (click)="close(data)"> OK </button>


### PR DESCRIPTION
Changed from showing the subject Id to the display name since Azure AD's subject id isn't user friendly.