### PR TITLE
updated $tenants variable reference

### DIFF
--- a/Fabric.Authorization.API/scripts/AzureAD-Users-Migration.ps1
+++ b/Fabric.Authorization.API/scripts/AzureAD-Users-Migration.ps1
@@ -535,7 +535,7 @@ $currentUserDomain = Get-CurrentUserDomain -quiet $quiet
 
 $authADDataSet = Get-ADUsers -authDataSet $authDataSet -domain $currentUserDomain
 
-$authAADDataSet = Get-AzureADUsers -authDataSet $authADDataSet -tenants $tenants
+$authAADDataSet = Get-AzureADUsers -authDataSet $authADDataSet -tenants $tenants.name
 
 # Add azureAD user to the AuthorizationDB Users table
 # Assigning to a variable keeps the xml information from getting output in powershell


### PR DESCRIPTION
Updated reference to $tenants variable on line 538.  Existing reference was pulling entire hashtable value instead of the tenant name value