### PR TITLE
use domain of user for querying

### DIFF
--- a/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.psm1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.psm1
@@ -398,6 +398,21 @@ function Get-SamAccountFromAccountName
     $samAccountName = $accountNameParts[1]
     return $samAccountName
 }
+
+function Get-SamDomainFromAccountName 
+{
+    param(
+        [Parameter(Mandatory=$true)]
+        [string] $accountName
+    )
+    $accountNameParts = $accountName.Split('\')
+    if ($accountNameParts.Count -ne 2) {
+        Write-DosMessage -Level "Error" -Message "Please enter an account in the form DOMAIN\account. Halting installation." 
+        throw
+    }
+    $samAccountDomain = $accountNameParts[0]
+    return $samAccountDomain
+}
     
 function Add-ListOfUsersToDosAdminGroup($edwAdminUsers, $connString, $authorizationServiceUrl, $accessToken) {	   
     # Get the group once, should be same for every user.
@@ -1296,3 +1311,4 @@ Export-ModuleMember Add-AuthorizationRegistration
 Export-ModuleMember Set-LoggingConfiguration
 Export-ModuleMember Get-PrincipalContext
 Export-ModuleMember Get-SamAccountFromAccountName 
+Export-ModuleMember Get-SamDomainFromAccountName 


### PR DESCRIPTION
2 scenarios:

1. This scenario.  We get the user and split it by its subject id to get Username and Domain.  Do a search and map this to AzureAD.  There were redundant calls that were removed.  Created a function to give the domain part of the name too.

2. The previous code took in a domain name.  Do we want to search AD just for the domain we have from the currently logged in user?  If we are scanning the database it makes sense to pull all users regardless of domain and map them based on that.  We will want to see how this may work.

Need some thoughts to get my head around this. 