### PR TITLE
Added Tests and printed better message for invalid account names.

### DIFF
--- a/Fabric.Authorization.API/scripts/AzureAD-Users-Migration.ps1
+++ b/Fabric.Authorization.API/scripts/AzureAD-Users-Migration.ps1
@@ -381,8 +381,16 @@ function Get-ADUsers
 
        [string] $subjectId = $user.SubjectId.ToString()
        # This script is in Install-Authorization-Utilities.psm1
-       $samAccountName = Get-SamAccountFromAccountName -accountName $subjectId 
-       $samDomainName = Get-SamDomainFromAccountName -accountName $subjectId
+       try
+       {
+           $samAccountName = Get-SamAccountFromAccountName -accountName $subjectId 
+           $samDomainName = Get-SamDomainFromAccountName -accountName $subjectId
+       }
+       catch 
+       {
+            Write-DosMessage -Level "Error" -Message "Could not understand account name: '$($subjectId)'. Skipping..."
+            continue
+       }
        
        # get all properties of the user with $samAccountName
        # You can find this script in ActiveDirectory module, located here:

--- a/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.tests.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization-Utilities.tests.ps1
@@ -381,6 +381,56 @@ Describe 'Get-SamAccountFromAccountName tests' -Tag 'Unit'{
 
             #Act
             {Get-SamAccountFromAccountName -accountName $accountName } |Should -Throw
+        }      
+        It 'Should throw an exception for only a user name' {
+            #Arrange
+            $accountName = "user"
+
+            #Act
+            {Get-SamAccountFromAccountName -accountName $accountName } |Should -Throw
+        }
+    }
+}
+
+Describe 'Get-SamDomainFromAccountName tests' -Tag 'Unit'{
+    InModuleScope Install-Authorization-Utilities{
+        It 'Should parse a valid account domain'{
+            #Arrange
+            $accountName = "domain\test.user"
+
+            #Act
+            $samAccountName = Get-SamDomainFromAccountName -accountName $accountName
+
+            #Assert
+            $samAccountName | Should -Be "domain"
+        }
+        It 'Should throw an exception for an invalid account domain'{
+            #Arrange
+            $accountName = "domain\test\user"
+
+            #Act
+            {Get-SamDomainFromAccountName -accountName $accountName } |Should -Throw
+        }
+        It 'Should throw an exception for a null account domain'{
+            #Arrange
+            $accountName = $null
+
+            #Act
+            {Get-SamDomainFromAccountName -accountName $accountName } |Should -Throw
+        }
+        It 'Should throw an exception for a empty account name'{
+            #Arrange
+            $accountName = ""
+
+            #Act
+            {Get-SamDomainFromAccountName -accountName $accountName } |Should -Throw
+        }      
+        It 'Should throw an exception for only a domain name' {
+            #Arrange
+            $accountName = "domain"
+
+            #Act
+            {Get-SamDomainFromAccountName -accountName $accountName } |Should -Throw
         }
     }
 }


### PR DESCRIPTION
@ctediz I missed your comment about the subjectId having a better output.  I have added a try catch to see if we can skip those.

Also added tests for the Get-SamAccountFromAccountName function