### PR TITLE
Login to discovery using windows auth

### DIFF
--- a/Fabric.Authorization.AccessControl/protractor.conf.js
+++ b/Fabric.Authorization.AccessControl/protractor.conf.js
@@ -47,7 +47,7 @@ exports.config = {
     const root = process.env.E2E_SERVERROOT || browser.params.serverRoot;
     browser.baseUrl = process.env.E2E_BASEURL || browser.baseUrl;
 
-    const discoveryUrl = `https://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${root}/DiscoveryService/v1`
+    const discoveryUrl = `https://${encodeURIComponent(username)}:${encodeURIComponent(password)}@${root}/DiscoveryService`
 
     console.log('Logging into Discovery');
 


### PR DESCRIPTION
Still not fully logging in when hitting the api,
but this accepts the credentials and should get the functional tests up and running in the meantime