### PR TITLE
Upgrade to .net core 2.1.10

### DIFF
--- a/Catalyst.Fabric.Authorization.Client.FunctionalTests/Catalyst.Fabric.Authorization.Client.FunctionalTests.csproj
+++ b/Catalyst.Fabric.Authorization.Client.FunctionalTests/Catalyst.Fabric.Authorization.Client.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Catalyst.Fabric.Authorization.Client.FunctionalTests/Catalyst.Fabric.Authorization.Client.FunctionalTests.csproj
+++ b/Catalyst.Fabric.Authorization.Client.FunctionalTests/Catalyst.Fabric.Authorization.Client.FunctionalTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Catalyst.Fabric.Authorization.Client.UnitTests.csproj
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Catalyst.Fabric.Authorization.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Catalyst.Fabric.Authorization.Client.UnitTests/Catalyst.Fabric.Authorization.Client.UnitTests.csproj
+++ b/Catalyst.Fabric.Authorization.Client.UnitTests/Catalyst.Fabric.Authorization.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -76,7 +76,7 @@ namespace Fabric.Authorization.API
             base.ConfigureRequestContainer(container, context);
             container.Register(new NancyContextWrapper(context));
             var appConfig = container.Resolve<IAppConfiguration>();
-            container.UseNewHttpRequestMessageFactory(context, appConfig.IdentityServerConfidentialClientSettings);
+            container.UseHttpRequestMessageFactory(context, appConfig.IdentityServerConfidentialClientSettings);
             container.RegisterServices(appConfig);
 
             var configurator = container.Resolve<IPersistenceConfigurator>();

--- a/Fabric.Authorization.API/Bootstrapper.cs
+++ b/Fabric.Authorization.API/Bootstrapper.cs
@@ -11,7 +11,6 @@ using Fabric.Authorization.API.Infrastructure.PipelineHooks;
 using Fabric.Authorization.API.Logging;
 using Fabric.Authorization.Domain.Events;
 using Fabric.Authorization.Domain.Services;
-using Fabric.Platform.Bootstrappers.Nancy;
 using LibOwin;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Caching.Memory;
@@ -55,9 +54,10 @@ namespace Fabric.Authorization.API
 
         protected override void RequestStartup(TinyIoCContainer container, IPipelines pipelines, NancyContext context)
         {
+			
             base.RequestStartup(container, pipelines, context);
             var owinEnvironment = context.GetOwinEnvironment();
-            if (owinEnvironment != null)
+            if (owinEnvironment != null && owinEnvironment.ContainsKey(OwinConstants.RequestUser))
             {
                 var principal = owinEnvironment[OwinConstants.RequestUser] as ClaimsPrincipal;
                 context.CurrentUser = principal;
@@ -76,7 +76,7 @@ namespace Fabric.Authorization.API
             base.ConfigureRequestContainer(container, context);
             container.Register(new NancyContextWrapper(context));
             var appConfig = container.Resolve<IAppConfiguration>();
-            container.UseHttpRequestMessageFactory(context, appConfig.IdentityServerConfidentialClientSettings);
+            container.UseNewHttpRequestMessageFactory(context, appConfig.IdentityServerConfidentialClientSettings);
             container.RegisterServices(appConfig);
 
             var configurator = container.Resolve<IPersistenceConfigurator>();

--- a/Fabric.Authorization.API/Dockerfile
+++ b/Fabric.Authorization.API/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.1
 ARG source
 WORKDIR /app
 EXPOSE 5004

--- a/Fabric.Authorization.API/Dockerfile
+++ b/Fabric.Authorization.API/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/aspnetcore:1.1.2
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2
 ARG source
 WORKDIR /app
 EXPOSE 5004

--- a/Fabric.Authorization.API/Extensions/TinyIocExtensions.cs
+++ b/Fabric.Authorization.API/Extensions/TinyIocExtensions.cs
@@ -6,13 +6,25 @@ using Fabric.Authorization.API.RemoteServices.IdentityProviderSearch.Providers;
 using Fabric.Authorization.API.Services;
 using Fabric.Authorization.Domain.Resolvers.Permissions;
 using Fabric.Authorization.Domain.Services;
+using Fabric.Platform.Http;
+using Fabric.Platform.Shared.Configuration;
+using Nancy;
+using Nancy.Owin;
 using Nancy.TinyIoc;
+using HttpRequestMessageFactory = Fabric.Authorization.API.Services.HttpRequestMessageFactory;
 
 namespace Fabric.Authorization.API.Extensions
 {
     public static class TinyIocExtensions
     {
-        public static TinyIoCContainer RegisterServices(this TinyIoCContainer container, IAppConfiguration appConfiguration)
+	    public static TinyIoCContainer UseNewHttpRequestMessageFactory(this TinyIoCContainer self, NancyContext context, IdentityServerConfidentialClientSettings settings)
+	    {
+		    var correlationToken = context.GetOwinEnvironment()?[Platform.Shared.Constants.FabricLogContextProperties.CorrelationTokenContextName] as string;
+		    self.Register<IHttpRequestMessageFactory>(new HttpRequestMessageFactory(settings.Authority, settings.ClientId, settings.ClientSecret,
+			    correlationToken ?? string.Empty, string.Empty));
+		    return self;
+	    }
+		public static TinyIoCContainer RegisterServices(this TinyIoCContainer container, IAppConfiguration appConfiguration)
         {
             container.Register<RoleService, RoleService>();
             container.Register<UserService, UserService>();

--- a/Fabric.Authorization.API/Extensions/TinyIocExtensions.cs
+++ b/Fabric.Authorization.API/Extensions/TinyIocExtensions.cs
@@ -17,7 +17,7 @@ namespace Fabric.Authorization.API.Extensions
 {
     public static class TinyIocExtensions
     {
-	    public static TinyIoCContainer UseNewHttpRequestMessageFactory(this TinyIoCContainer self, NancyContext context, IdentityServerConfidentialClientSettings settings)
+	    public static TinyIoCContainer UseHttpRequestMessageFactory(this TinyIoCContainer self, NancyContext context, IdentityServerConfidentialClientSettings settings)
 	    {
 		    var correlationToken = context.GetOwinEnvironment()?[Platform.Shared.Constants.FabricLogContextProperties.CorrelationTokenContextName] as string;
 		    self.Register<IHttpRequestMessageFactory>(new HttpRequestMessageFactory(settings.Authority, settings.ClientId, settings.ClientSecret,

--- a/Fabric.Authorization.API/Fabric.Authorization.API.csproj
+++ b/Fabric.Authorization.API/Fabric.Authorization.API.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <DebugType>Full</DebugType>
     <Company>Health Catalyst</Company>
@@ -88,7 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.10" />
     <PackageReference Include="Fabric.Platform.Bootstrappers.Nancy" Version="1.0.2018081702" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />

--- a/Fabric.Authorization.API/Fabric.Authorization.API.csproj
+++ b/Fabric.Authorization.API/Fabric.Authorization.API.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
     <DebugType>Full</DebugType>
     <Company>Health Catalyst</Company>
     <Product>Fabric.Authorization</Product>
-    <Copyright>Copyright © 2018</Copyright>
+    <Copyright>Copyright © 2019</Copyright>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' == '' ">1.0.0.0-local</Version>
     <Version Condition=" '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</Version>
   </PropertyGroup>
@@ -87,15 +87,10 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="2.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.2.2" />
     <PackageReference Include="Fabric.Platform.Bootstrappers.Nancy" Version="1.0.2018081702" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="1.1.2" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="1.1.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.5" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.TraceSource" Version="1.1.2" />
     <PackageReference Include="Nancy" Version="2.0.0-clinteastwood" />
     <PackageReference Include="Nancy.Swagger" Version="2.2.29-alpha" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />

--- a/Fabric.Authorization.API/Program.cs
+++ b/Fabric.Authorization.API/Program.cs
@@ -1,29 +1,19 @@
-﻿using System.IO;
-using Fabric.Authorization.API.Configuration;
-using Fabric.Authorization.API.Extensions;
-using Fabric.Authorization.API.Services;
+﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Internal;
 
 namespace Fabric.Authorization.API
 {
     public class Program
     {
-        public static void Main(string[] args)
-        {
-            var appConfig =
-                new AuthorizationConfigurationProvider(new WindowsCertificateService()).GetAppConfiguration(Directory
-                    .GetCurrentDirectory());
+		public static void Main(string[] args)
+		{
+			BuildWebHost(args).Run();
+		}
 
-            var host = new WebHostBuilder()
-                .UseApplicationInsights()
-                .UseKestrel()
-                .UseUrls("http://*:5004")
-                .UseContentRoot(Directory.GetCurrentDirectory())
-                .UseStartup<Startup>()
-                .UseIisIntegrationIfConfigured(appConfig)
-                .Build();
-
-            host.Run();
-        }
-    }
+		public static IWebHost BuildWebHost(string[] args) =>
+			WebHost.CreateDefaultBuilder(args)
+				.UseStartup<Startup>()
+				.Build();
+	}
 }

--- a/Fabric.Authorization.API/Program.cs
+++ b/Fabric.Authorization.API/Program.cs
@@ -13,6 +13,7 @@ namespace Fabric.Authorization.API
 
 		public static IWebHost BuildWebHost(string[] args) =>
 			WebHost.CreateDefaultBuilder(args)
+				.UseUrls("http://*:5004")
 				.UseStartup<Startup>()
 				.Build();
 	}

--- a/Fabric.Authorization.API/Services/HttpRequestMessageFactory.cs
+++ b/Fabric.Authorization.API/Services/HttpRequestMessageFactory.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Fabric.Platform.Http;
+using IdentityModel.Client;
+
+namespace Fabric.Authorization.API.Services
+{
+	public class HttpRequestMessageFactory : IHttpRequestMessageFactory
+	{
+		private readonly string _correlationToken;
+		private readonly string _subject;
+		private readonly TokenClient _tokenClient;
+
+		public HttpRequestMessageFactory(string tokenUrl, string clientId, string secret, string correlationToken, string subject)
+		{
+			_correlationToken = correlationToken;
+			_subject = subject;
+			_tokenClient = new TokenClient(tokenUrl, clientId, secret);
+		}
+		public async Task<HttpRequestMessage> Create(HttpMethod httpMethod, Uri uri, string requestScope)
+		{
+			var response = await _tokenClient.RequestClientCredentialsAsync(requestScope).ConfigureAwait(false);
+			return CreateWithAccessToken(httpMethod, uri, response.AccessToken);
+		}
+
+		public HttpRequestMessage CreateWithAccessToken(HttpMethod httpMethod, Uri uri, string accessToken)
+		{
+			var httpRequestMessage = new HttpRequestMessage(httpMethod, uri);
+			httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+
+			httpRequestMessage.Headers.Add(Platform.Shared.Constants.FabricHeaders.CorrelationTokenHeaderName, _correlationToken);
+			if (!string.IsNullOrEmpty(_subject))
+			{
+				httpRequestMessage.Headers.Add(Platform.Shared.Constants.FabricHeaders.SubjectNameHeader, _subject);
+			}
+			return httpRequestMessage;
+		}
+	}
+}

--- a/Fabric.Authorization.API/scripts/Install-Authorization.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization.ps1
@@ -56,7 +56,7 @@ Set-LoggingConfiguration -commonConfig $commonInstallSettings
 
 $currentDirectory = $PSScriptRoot
 $zipPackage = Get-FullyQualifiedInstallationZipFile -zipPackage $installSettings.zipPackage -workingDirectory $currentDirectory
-Install-DotNetCoreIfNeeded -version "2.2.2.0" -downloadUrl "https://download.visualstudio.microsoft.com/download/pr/5efd5ee8-4df6-4b99-9feb-87250f1cd09f/552f4b0b0340e447bab2f38331f833c5/dotnet-hosting-2.2.2-win.exe"
+Install-DotNetCoreIfNeeded -version "2.1.10.0" -downloadUrl "https://download.visualstudio.microsoft.com/download/pr/34ad5a08-c67b-4c6f-a65f-47cb5a83747a/02d897904bd52e8681412e353660ac66/dotnet-hosting-2.1.10-win.exe"
 Install-UrlRewriteIfNeeded -version "7.2.1952" -downloadUrl "http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi"
 $selectedSite = Get-IISWebSiteForInstall -selectedSiteName $installSettings.siteName -quiet $quiet -installConfigPath $installConfigPath -scope $installSettingsScope
 $selectedCerts = Get-Certificates -primarySigningCertificateThumbprint $installSettings.encryptionCertificateThumbprint -encryptionCertificateThumbprint $installSettings.encryptionCertificateThumbprint -installConfigPath $installConfigPath -scope $installSettingsScope -quiet $quiet

--- a/Fabric.Authorization.API/scripts/Install-Authorization.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization.ps1
@@ -56,7 +56,7 @@ Set-LoggingConfiguration -commonConfig $commonInstallSettings
 
 $currentDirectory = $PSScriptRoot
 $zipPackage = Get-FullyQualifiedInstallationZipFile -zipPackage $installSettings.zipPackage -workingDirectory $currentDirectory
-Install-DotNetCoreIfNeeded -version "1.1.30503.82" -downloadUrl "https://go.microsoft.com/fwlink/?linkid=848766"
+Install-DotNetCoreIfNeeded -version "2.2.2.0" -downloadUrl "https://download.visualstudio.microsoft.com/download/pr/5efd5ee8-4df6-4b99-9feb-87250f1cd09f/552f4b0b0340e447bab2f38331f833c5/dotnet-hosting-2.2.2-win.exe"
 Install-UrlRewriteIfNeeded -version "7.2.1952" -downloadUrl "http://download.microsoft.com/download/D/D/E/DDE57C26-C62C-4C59-A1BB-31D58B36ADA2/rewrite_amd64_en-US.msi"
 $selectedSite = Get-IISWebSiteForInstall -selectedSiteName $installSettings.siteName -quiet $quiet -installConfigPath $installConfigPath -scope $installSettingsScope
 $selectedCerts = Get-Certificates -primarySigningCertificateThumbprint $installSettings.encryptionCertificateThumbprint -encryptionCertificateThumbprint $installSettings.encryptionCertificateThumbprint -installConfigPath $installConfigPath -scope $installSettingsScope -quiet $quiet

--- a/Fabric.Authorization.API/scripts/run-integration-tests.sh
+++ b/Fabric.Authorization.API/scripts/run-integration-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 "/C/Program Files (x86)/Microsoft Visual Studio/2017/Professional/MSBuild/15.0/Bin/MSBuild.exe" ../../Fabric.Authorization.SqlServer/Fabric.Authorization.SqlServer.sqlproj
-cp ../../Fabric.Authorization.SqlServer/bin/Debug/Fabric.Authorization.SqlServer_Create.sql ../../Fabric.Authorization.IntegrationTests/bin/Debug/netcoreapp2.2/Fabric.Authorization.SqlServer_Create.sql
+cp ../../Fabric.Authorization.SqlServer/bin/Debug/Fabric.Authorization.SqlServer_Create.sql ../../Fabric.Authorization.IntegrationTests/bin/Debug/netcoreapp2.1/Fabric.Authorization.SqlServer_Create.sql
 
 dotnet test ../../Fabric.Authorization.IntegrationTests/Fabric.Authorization.IntegrationTests.csproj

--- a/Fabric.Authorization.API/scripts/run-integration-tests.sh
+++ b/Fabric.Authorization.API/scripts/run-integration-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 "/C/Program Files (x86)/Microsoft Visual Studio/2017/Professional/MSBuild/15.0/Bin/MSBuild.exe" ../../Fabric.Authorization.SqlServer/Fabric.Authorization.SqlServer.sqlproj
-cp ../../Fabric.Authorization.SqlServer/bin/Debug/Fabric.Authorization.SqlServer_Create.sql ../../Fabric.Authorization.IntegrationTests/bin/Debug/netcoreapp1.1/Fabric.Authorization.SqlServer_Create.sql
+cp ../../Fabric.Authorization.SqlServer/bin/Debug/Fabric.Authorization.SqlServer_Create.sql ../../Fabric.Authorization.IntegrationTests/bin/Debug/netcoreapp2.2/Fabric.Authorization.SqlServer_Create.sql
 
 dotnet test ../../Fabric.Authorization.IntegrationTests/Fabric.Authorization.IntegrationTests.csproj

--- a/Fabric.Authorization.AccessControl/README.md
+++ b/Fabric.Authorization.AccessControl/README.md
@@ -8,7 +8,7 @@ If you would like to run the Access Control UI against a development version of 
 
 - Run the `setup-dependencies.ps1` PowerShell script as administrator to ensure you have the correct versions of node, npm, angular and typescript installed.
 - In Fabric.Authorization.API/appsettings.json, update the `IdentityServerConfidentialClientSettings.Authority` setting to point at your installed version of Fabric.Identity, e.g. `https://host.domain.local/identity`
-- Execute `npm run watch` to build the angular application and watch for changes
+- Launch PowerShell or gitbash as administrator and in Fabric.Authorization.AccessControl folder execute `npm install' then `npm run watch` to build the angular application and watch for changes
 - In VS 2017 ensure the startup project is `Fabric.Authorization.API` and the debug profile is set to `IIS`.
 - In VS 2017 begin debugging by pressing `F5`
 - In IIS, a new web application will be created `AuthorizationDev`.  You will need to change the app pool; I suggest changing it the the same one as Authorization.

--- a/Fabric.Authorization.Domain/Fabric.Authorization.Domain.csproj
+++ b/Fabric.Authorization.Domain/Fabric.Authorization.Domain.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DebugType>Full</DebugType>
   </PropertyGroup>
 
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.5.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="1.4.0" />
     <PackageReference Include="FluentValidation" Version="7.1.1" />

--- a/Fabric.Authorization.IntegrationTests/Fabric.Authorization.IntegrationTests.csproj
+++ b/Fabric.Authorization.IntegrationTests/Fabric.Authorization.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <DebugType>Full</DebugType>
   </PropertyGroup>
 

--- a/Fabric.Authorization.IntegrationTests/Fabric.Authorization.IntegrationTests.csproj
+++ b/Fabric.Authorization.IntegrationTests/Fabric.Authorization.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>Full</DebugType>
   </PropertyGroup>
 

--- a/Fabric.Authorization.IntegrationTests/Services/GroupMigratorServiceTests.cs
+++ b/Fabric.Authorization.IntegrationTests/Services/GroupMigratorServiceTests.cs
@@ -50,7 +50,7 @@ namespace Fabric.Authorization.IntegrationTests.Services
             _fixture = fixture;
         }
 
-        [Fact]
+        [Fact(Skip = "Skip due to case sensitive query in EF Core 2.2 in memory provider")]
         public async Task MigrateDuplicateGroups_NoDuplicates_Success()
         {
             var container = _fixture.Bootstrapper.TinyIoCContainer;
@@ -146,7 +146,7 @@ namespace Fabric.Authorization.IntegrationTests.Services
             await groupStore.Delete(group2.ToModel());
         }
 
-        [Fact]
+        [Fact(Skip = "Skip due to case sensitive query in EF Core 2.2 in memory provider")]
         public async Task MigrateDuplicateDirectoryGroups_DuplicateNames_SuccessAsync()
         {
             var container = _fixture.Bootstrapper.TinyIoCContainer;
@@ -388,13 +388,13 @@ namespace Fabric.Authorization.IntegrationTests.Services
             await groupStore.Delete(group2.ToModel());
         }
 
-        [Fact]
+        [Fact(Skip = "Skip due to case sensitive query in EF Core 2.2 in memory provider")]
         public async Task MigrateDuplicateCustomGroups_DuplicateNames_SuccessAsync()
         {
             
         }
 
-        [Fact]
+        [Fact(Skip = "Skip due to case sensitive query in EF Core 2.2 in memory provider")]
         public async Task MigrateDuplicateGroups_HasDuplicateIdentifiers_SuccessAsync()
         {
             var container = _fixture.Bootstrapper.TinyIoCContainer;
@@ -670,7 +670,7 @@ namespace Fabric.Authorization.IntegrationTests.Services
             await groupStore.Delete(group3.ToModel());
         }
 
-        [Fact]
+        [Fact(Skip = "Skip due to case sensitive query in EF Core 2.2 in memory provider")]
         public async Task MigrateGroupSource_HasWindowsSource_SuccessAsync()
         {
             var container = _fixture.Bootstrapper.TinyIoCContainer;

--- a/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerGroupMigratorServiceTests.cs
+++ b/Fabric.Authorization.IntegrationTests/SqlServer/SqlServerGroupMigratorServiceTests.cs
@@ -1,20 +1,767 @@
-﻿using Fabric.Authorization.API.Constants;
-using Fabric.Authorization.IntegrationTests.Services;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Catalyst.Fabric.Authorization.Models;
+using Fabric.Authorization.API.Constants;
+using Fabric.Authorization.Domain;
+using Fabric.Authorization.Domain.Services;
+using Fabric.Authorization.Domain.Stores;
+using Fabric.Authorization.Persistence.SqlServer.Configuration;
+using Fabric.Authorization.Persistence.SqlServer.EntityModels;
+using Fabric.Authorization.Persistence.SqlServer.Mappers;
+using Fabric.Authorization.Persistence.SqlServer.Services;
+using Nancy.Helpers;
+using Nancy.Testing;
 using Xunit;
 
 namespace Fabric.Authorization.IntegrationTests.SqlServer
 {
     [Collection("SqlServerTests")]
-    public class SqlServerGroupMigratorServiceTests : GroupMigratorServiceTests
+    public class SqlServerGroupMigratorServiceTests : IClassFixture<IntegrationTestsFixture>
     {
+        protected readonly Browser Browser;
+        private readonly IntegrationTestsFixture _fixture;
+        private readonly string _storageProvider;
+
+        protected ClaimsPrincipal Principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+        {
+            new Claim(Claims.Scope, Scopes.ManageClientsScope),
+            new Claim(Claims.Scope, Scopes.ReadScope),
+            new Claim(Claims.Scope, Scopes.WriteScope),
+            new Claim(Claims.ClientId, "rolesprincipal"),
+            new Claim(Claims.IdentityProvider, "idP1")
+        }, "rolesprincipal"));
+
         public SqlServerGroupMigratorServiceTests(
             IntegrationTestsFixture fixture,
-            SqlServerIntegrationTestsFixture sqlFixture) : base(
-                fixture,
-                StorageProviders.SqlServer,
-                sqlFixture.ConnectionStrings)
+            SqlServerIntegrationTestsFixture sqlFixture,
+            string storageProvider = StorageProviders.SqlServer)
+        {
+            _fixture = fixture;
+            _fixture.ConnectionStrings = sqlFixture.ConnectionStrings;
+            Browser = fixture.GetBrowser(Principal, storageProvider);
+            fixture.CreateClient(Browser, "rolesprincipal");
+            _storageProvider = storageProvider;
+        }
+
+        [Fact]
+        public async Task MigrateDuplicateGroups_NoDuplicates_Success()
+        {
+            var container = _fixture.Bootstrapper.TinyIoCContainer;
+            var dbContext = container.Resolve<IAuthorizationDbContext>();
+            var groupMigratorService = container.Resolve<GroupMigratorService>();
+
+            var customGroup1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 1-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var customGroup2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 2-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var group1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Group 1-{Guid.NewGuid()}",
+                Source = GroupConstants.DirectorySource,
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var group2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Group 2-{Guid.NewGuid()}",
+                Source = GroupConstants.DirectorySource,
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var childGroup1 = new ChildGroup
+            {
+                ChildGroupId = group1.GroupId,
+                ParentGroupId = customGroup1.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var childGroup2 = new ChildGroup
+            {
+                ChildGroupId = group2.GroupId,
+                ParentGroupId = customGroup1.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var childGroup3 = new ChildGroup
+            {
+                ChildGroupId = group2.GroupId,
+                ParentGroupId = customGroup2.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            dbContext.Groups.AddRange(new List<Group>
+            {
+                customGroup1,
+                customGroup2,
+                group1,
+                group2
+            });
+
+            dbContext.ChildGroups.AddRange(new List<ChildGroup>
+            {
+                childGroup1,
+                childGroup2,
+                childGroup3
+            });
+
+            dbContext.SaveChanges();
+
+            var result = await groupMigratorService.MigrateDuplicateGroups();
+            Assert.Empty(result.GroupMigrationRecords);
+
+            var groupStore = container.Resolve<IGroupStore>();
+            await groupStore.Delete(customGroup1.ToModel());
+            await groupStore.Delete(customGroup2.ToModel());
+            await groupStore.Delete(group1.ToModel());
+            await groupStore.Delete(group2.ToModel());
+        }
+
+        [Fact]
+        public async Task MigrateDuplicateDirectoryGroups_DuplicateNames_SuccessAsync()
+        {
+            var container = _fixture.Bootstrapper.TinyIoCContainer;
+            var dbContext = container.Resolve<IAuthorizationDbContext>();
+            var groupMigratorService = container.Resolve<GroupMigratorService>();
+
+            #region Data Setup
+
+            var client = new Client
+            {
+                ClientId = $"client1-{Guid.NewGuid()}",
+                Name = $"Client 1-{Guid.NewGuid()}"
+            };
+
+            var grain = new Grain
+            {
+                Name = $"dos-{Guid.NewGuid()}"
+            };
+
+            var securableItem = new SecurableItem
+            {
+                Name = $"datamarts-{Guid.NewGuid()}",
+                Grain = grain,
+                ClientOwner = client.ClientId
+            };
+
+            client.TopLevelSecurableItem = securableItem;
+
+            var customGroup1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 1-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var customGroup2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 2-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var groupGuid = Guid.NewGuid();
+            var group1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Group 1-{groupGuid}",
+                Source = GroupConstants.DirectorySource,
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var group2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"groUP 1-{groupGuid}",
+                Source = GroupConstants.DirectorySource,
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var role1 = new Role
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "Role 1",
+                Grain = grain.Name,
+                SecurableItem = securableItem
+            };
+
+            var role2 = new Role
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "Role 2",
+                Grain = grain.Name,
+                SecurableItem = securableItem,
+            };
+
+            var role3 = new Role
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "Role 3",
+                Grain = grain.Name,
+                SecurableItem = securableItem,
+            };
+
+            var group1Role1 = new GroupRole
+            {
+                Group = group1,
+                Role = role1
+            };
+
+            var group2Role1 = new GroupRole
+            {
+                Group = group2,
+                Role = role1
+            };
+
+            var group2Role2 = new GroupRole
+            {
+                Group = group2,
+                Role = role2
+            };
+
+            var group2Role3 = new GroupRole
+            {
+                Group = group2,
+                Role = role3,
+                IsDeleted = true
+            };
+
+            var user1 = new User
+            {
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                SubjectId = Guid.NewGuid().ToString()
+            };
+
+            var customGroup1User1 = new GroupUser
+            {
+                Group = customGroup1,
+                User = user1
+            };
+
+            var customGroup2User1 = new GroupUser
+            {
+                Group = customGroup2,
+                User = user1
+            };
+
+            var childGroup1 = new ChildGroup
+            {
+                ChildGroupId = group1.GroupId,
+                ParentGroupId = customGroup1.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var childGroup2 = new ChildGroup
+            {
+                ChildGroupId = group2.GroupId,
+                ParentGroupId = customGroup1.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var childGroup3 = new ChildGroup
+            {
+                ChildGroupId = group2.GroupId,
+                ParentGroupId = customGroup2.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            dbContext.Clients.Add(client);
+            dbContext.Grains.Add(grain);
+            dbContext.SecurableItems.Add(securableItem);
+
+            dbContext.Roles.AddRange(new List<Role>
+            {
+                role1,
+                role2,
+                role3
+            });
+
+            dbContext.Groups.AddRange(new List<Group>
+            {
+                customGroup1,
+                customGroup2,
+                group1,
+                group2
+            });
+
+            dbContext.GroupRoles.AddRange(new List<GroupRole>
+            {
+                group1Role1,
+                group2Role1,
+                group2Role2,
+                group2Role3
+            });
+
+            dbContext.Users.Add(user1);
+
+            dbContext.GroupUsers.AddRange(new List<GroupUser>
+            {
+                customGroup1User1,
+                customGroup2User1
+            });
+
+            dbContext.ChildGroups.AddRange(new List<ChildGroup>
+            {
+                childGroup1,
+                childGroup2,
+                childGroup3
+            });
+
+            dbContext.SaveChanges();
+
+            #endregion
+
+            var results = await groupMigratorService.MigrateDuplicateGroups();
+            Assert.Equal(1, results.GroupMigrationRecords.Count);
+            Assert.Empty(results.GroupMigrationRecords.SelectMany(r => r.Errors));
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(Claims.Scope, Scopes.ManageClientsScope),
+                new Claim(Claims.Scope, Scopes.ReadScope),
+                new Claim(Claims.Scope, Scopes.WriteScope),
+                new Claim(Claims.ClientId, client.ClientId),
+                new Claim(Claims.IdentityProvider, "idP1")
+            }, "rolesprincipal"));
+
+            var browser = _fixture.GetBrowser(principal, _storageProvider);
+
+            var getResponse = await browser.Get(HttpUtility.UrlEncode($"/groups/Group 1-{groupGuid}"), with =>
+            {
+                with.HttpRequest();
+            });
+
+            var groupRoleApiModel = getResponse.Body.DeserializeJson<GroupRoleApiModel>();
+            var roles = groupRoleApiModel.Roles.ToList();
+            Assert.Equal(2, roles.Count);
+            Assert.Contains(roles, r => r.Name == role1.Name);
+            Assert.Contains(roles, r => r.Name == role2.Name);
+
+            var parents = groupRoleApiModel.Parents.ToList();
+            Assert.Contains(parents, p => p.GroupName == customGroup1.Name);
+            Assert.Contains(parents, p => p.GroupName == customGroup2.Name);
+
+            var groupStore = container.Resolve<IGroupStore>();
+            await groupStore.Delete(customGroup1.ToModel());
+            await groupStore.Delete(customGroup2.ToModel());
+            await groupStore.Delete(group1.ToModel());
+            await groupStore.Delete(group2.ToModel());
+        }
+
+        [Fact]
+        public async Task MigrateDuplicateCustomGroups_DuplicateNames_SuccessAsync()
         {
 
+        }
+
+        [Fact]
+        public async Task MigrateDuplicateGroups_HasDuplicateIdentifiers_SuccessAsync()
+        {
+            var container = _fixture.Bootstrapper.TinyIoCContainer;
+            var dbContext = container.Resolve<IAuthorizationDbContext>();
+            var groupMigratorService = container.Resolve<GroupMigratorService>();
+
+            #region Data Setup
+
+            var client = new Client
+            {
+                ClientId = $"client1-{Guid.NewGuid()}",
+                Name = $"Client 1-{Guid.NewGuid()}"
+            };
+
+            var grain = new Grain
+            {
+                Name = $"dos-{Guid.NewGuid()}"
+            };
+
+            var securableItem = new SecurableItem
+            {
+                Name = $"datamarts-{Guid.NewGuid()}",
+                Grain = grain,
+                ClientOwner = client.ClientId
+            };
+
+            client.TopLevelSecurableItem = securableItem;
+
+            var customGroup1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 1-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var customGroup2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 2-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var groupGuid = Guid.NewGuid();
+            var group1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Group 1-{groupGuid}",
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                TenantId = "12345",
+                Source = GroupConstants.DirectorySource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var group2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"groUP 1-{groupGuid}",
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                TenantId = "12345",
+                Source = GroupConstants.DirectorySource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var group3 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"groUP 1-{groupGuid}",
+                IdentityProvider = IdentityConstants.AzureActiveDirectory,
+                TenantId = "12345",
+                Source = GroupConstants.DirectorySource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var role1 = new Role
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "Role 1",
+                Grain = grain.Name,
+                SecurableItem = securableItem
+            };
+
+            var role2 = new Role
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "Role 2",
+                Grain = grain.Name,
+                SecurableItem = securableItem,
+            };
+
+            var role3 = new Role
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "Role 3",
+                Grain = grain.Name,
+                SecurableItem = securableItem,
+            };
+
+            var role4 = new Role
+            {
+                RoleId = Guid.NewGuid(),
+                Name = "Role 4",
+                Grain = grain.Name,
+                SecurableItem = securableItem,
+            };
+
+            var group1Role1 = new GroupRole
+            {
+                Group = group1,
+                Role = role1
+            };
+
+            var group2Role1 = new GroupRole
+            {
+                Group = group2,
+                Role = role1
+            };
+
+            var group2Role2 = new GroupRole
+            {
+                Group = group2,
+                Role = role2
+            };
+
+            var group2Role3 = new GroupRole
+            {
+                Group = group2,
+                Role = role3,
+                IsDeleted = true
+            };
+
+            var group3Role4 = new GroupRole
+            {
+                Group = group3,
+                Role = role4
+            };
+
+            var user1 = new User
+            {
+                IdentityProvider = IdentityConstants.ActiveDirectory,
+                SubjectId = Guid.NewGuid().ToString()
+            };
+
+            var customGroup1User1 = new GroupUser
+            {
+                Group = customGroup1,
+                User = user1
+            };
+
+            var customGroup2User1 = new GroupUser
+            {
+                Group = customGroup2,
+                User = user1
+            };
+
+            var childGroup1 = new ChildGroup
+            {
+                ChildGroupId = group1.GroupId,
+                ParentGroupId = customGroup1.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var childGroup2 = new ChildGroup
+            {
+                ChildGroupId = group2.GroupId,
+                ParentGroupId = customGroup1.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var childGroup3 = new ChildGroup
+            {
+                ChildGroupId = group2.GroupId,
+                ParentGroupId = customGroup2.GroupId,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            dbContext.Clients.Add(client);
+            dbContext.Grains.Add(grain);
+            dbContext.SecurableItems.Add(securableItem);
+
+            dbContext.Roles.AddRange(new List<Role>
+            {
+                role1,
+                role2,
+                role3,
+                role4
+            });
+
+            dbContext.Groups.AddRange(new List<Group>
+            {
+                customGroup1,
+                customGroup2,
+                group1,
+                group2,
+                group3
+            });
+
+            dbContext.GroupRoles.AddRange(new List<GroupRole>
+            {
+                group1Role1,
+                group2Role1,
+                group2Role2,
+                group2Role3,
+                group3Role4
+            });
+
+            dbContext.Users.Add(user1);
+
+            dbContext.GroupUsers.AddRange(new List<GroupUser>
+            {
+                customGroup1User1,
+                customGroup2User1
+            });
+
+            dbContext.ChildGroups.AddRange(new List<ChildGroup>
+            {
+                childGroup1,
+                childGroup2,
+                childGroup3
+            });
+
+            dbContext.SaveChanges();
+
+            #endregion
+
+            var results = await groupMigratorService.MigrateDuplicateGroups();
+            Assert.Equal(1, results.GroupMigrationRecords.Count);
+            Assert.Empty(results.GroupMigrationRecords.SelectMany(r => r.Errors));
+
+            var principal = new ClaimsPrincipal(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(Claims.Scope, Scopes.ManageClientsScope),
+                new Claim(Claims.Scope, Scopes.ReadScope),
+                new Claim(Claims.Scope, Scopes.WriteScope),
+                new Claim(Claims.ClientId, client.ClientId),
+                new Claim(Claims.IdentityProvider, "idP1")
+            }, "rolesprincipal"));
+
+            var browser = _fixture.GetBrowser(principal, _storageProvider);
+
+            var getResponse = await browser.Get(HttpUtility.UrlEncode($"/groups/Group 1-{groupGuid}"), with =>
+            {
+                with.HttpRequest();
+                with.Header("Accept", "application/json");
+                with.Query("identityProvider", IdentityConstants.ActiveDirectory);
+                with.Query("tenantId", "12345");
+            });
+
+            var groupRoleApiModel = getResponse.Body.DeserializeJson<GroupRoleApiModel>();
+            var roles = groupRoleApiModel.Roles.ToList();
+            Assert.Equal(2, roles.Count);
+            Assert.Contains(roles, r => r.Name == role1.Name);
+            Assert.Contains(roles, r => r.Name == role2.Name);
+
+            var parents = groupRoleApiModel.Parents.ToList();
+            Assert.Contains(parents, p => p.GroupName == customGroup1.Name);
+            Assert.Contains(parents, p => p.GroupName == customGroup2.Name);
+
+            var groupStore = container.Resolve<IGroupStore>();
+            await groupStore.Delete(customGroup1.ToModel());
+            await groupStore.Delete(customGroup2.ToModel());
+            await groupStore.Delete(group1.ToModel());
+            await groupStore.Delete(group2.ToModel());
+            await groupStore.Delete(group3.ToModel());
+        }
+
+        [Fact]
+        public async Task MigrateGroupSource_HasWindowsSource_SuccessAsync()
+        {
+            var container = _fixture.Bootstrapper.TinyIoCContainer;
+            var dbContext = container.Resolve<IAuthorizationDbContext>();
+            var groupMigratorService = container.Resolve<GroupMigratorService>();
+
+            var customGroup1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 1-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var customGroup2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Custom Group 2-{Guid.NewGuid()}",
+                Source = GroupConstants.CustomSource,
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var group1 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Group 1-{Guid.NewGuid()}",
+                Source = "windows",
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            var group2 = new Group
+            {
+                GroupId = Guid.NewGuid(),
+                Name = $"Group 2-{Guid.NewGuid()}",
+                Source = "Windows",
+                CreatedBy = "test",
+                CreatedDateTimeUtc = DateTime.UtcNow
+            };
+
+            dbContext.Groups.AddRange(new List<Group>
+            {
+                customGroup1,
+                customGroup2,
+                group1,
+                group2
+            });
+
+            dbContext.SaveChanges();
+
+            await groupMigratorService.MigrateWindowsSourceToDirectory();
+            await groupMigratorService.MigrateIdentityProvider();
+
+            // group 1
+            var browser = _fixture.GetBrowser(Principal, _storageProvider);
+            var getResponse = await browser.Get(HttpUtility.UrlEncode($"/groups/{group1.Name}"), with =>
+            {
+                with.HttpRequest();
+            });
+
+            var groupRoleApiModel = getResponse.Body.DeserializeJson<GroupRoleApiModel>();
+            Assert.True(groupRoleApiModel.GroupSource == GroupConstants.DirectorySource);
+            Assert.True(groupRoleApiModel.IdentityProvider == IdentityConstants.ActiveDirectory);
+
+            // group 2
+            getResponse = await browser.Get(HttpUtility.UrlEncode($"/groups/{group2.Name}"), with =>
+            {
+                with.HttpRequest();
+            });
+
+            groupRoleApiModel = getResponse.Body.DeserializeJson<GroupRoleApiModel>();
+            Assert.True(groupRoleApiModel.GroupSource == GroupConstants.DirectorySource);
+            Assert.True(groupRoleApiModel.IdentityProvider == IdentityConstants.ActiveDirectory);
+
+            // custom group 1
+            getResponse = await browser.Get(HttpUtility.UrlEncode($"/groups/{customGroup1.Name}"), with =>
+            {
+                with.HttpRequest();
+            });
+
+            groupRoleApiModel = getResponse.Body.DeserializeJson<GroupRoleApiModel>();
+            Assert.True(groupRoleApiModel.GroupSource == GroupConstants.CustomSource);
+            Assert.Null(groupRoleApiModel.IdentityProvider);
+
+            // custom group 2
+            getResponse = await browser.Get(HttpUtility.UrlEncode($"/groups/{customGroup2.Name}"), with =>
+            {
+                with.HttpRequest();
+            });
+
+            groupRoleApiModel = getResponse.Body.DeserializeJson<GroupRoleApiModel>();
+            Assert.True(groupRoleApiModel.GroupSource == GroupConstants.CustomSource);
+            Assert.Null(groupRoleApiModel.IdentityProvider);
         }
     }
 }

--- a/Fabric.Authorization.Persistence.SqlServer/Extensions/EDWModelBuilderExtensions.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Extensions/EDWModelBuilderExtensions.cs
@@ -42,12 +42,12 @@ namespace Fabric.Authorization.Persistence.SqlServer.Extensions
                 entity.HasKey(p => p.Id);
                 
                 entity.Property(p => p.Id)
-                    .ForSqlServerHasColumnName("IdentityID")
+                    .HasColumnName("IdentityID")
                     .ValueGeneratedOnAdd()
                     .UseSqlServerIdentityColumn();
 
                 entity.Property(p => p.Name)
-                    .ForSqlServerHasColumnName("IdentityNM")
+                    .HasColumnName("IdentityNM")
                     .HasMaxLength(255)
                     .IsRequired();
 
@@ -66,17 +66,17 @@ namespace Fabric.Authorization.Persistence.SqlServer.Extensions
                 entity.HasKey(p => p.Id);
 
                 entity.Property(p => p.Id)
-                    .ForSqlServerHasColumnName("RoleID")
+                    .HasColumnName("RoleID")
                     .ValueGeneratedOnAdd()
                     .UseSqlServerIdentityColumn();
 
                 entity.Property(p => p.Name)
-                    .ForSqlServerHasColumnName("RoleNM")
+                    .HasColumnName("RoleNM")
                     .HasMaxLength(255)
                     .IsRequired();
                 
                 entity.Property(p => p.Description)
-                    .ForSqlServerHasColumnName("RoleDSC")
+                    .HasColumnName("RoleDSC")
                     .HasMaxLength(4000);
 
                 entity.HasMany(p => p.EDWIdentityRoles)

--- a/Fabric.Authorization.Persistence.SqlServer/Fabric.Authorization.Persistence.SqlServer.csproj
+++ b/Fabric.Authorization.Persistence.SqlServer/Fabric.Authorization.Persistence.SqlServer.csproj
@@ -1,19 +1,19 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="1.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="1.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="1.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="1.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="1.1.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="1.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.2" />
     <PackageReference Include="Serilog.Sinks.MSSqlServerCore" Version="1.1.0" />
   </ItemGroup>
 

--- a/Fabric.Authorization.Persistence.SqlServer/Services/AuthorizationDbContext.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Services/AuthorizationDbContext.cs
@@ -7,7 +7,7 @@ using Fabric.Authorization.Persistence.SqlServer.Configuration;
 using Fabric.Authorization.Persistence.SqlServer.EntityModels;
 using Fabric.Authorization.Persistence.SqlServer.Extensions;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Client = Fabric.Authorization.Persistence.SqlServer.EntityModels.Client;
 using Grain = Fabric.Authorization.Persistence.SqlServer.EntityModels.Grain;

--- a/Fabric.Authorization.UnitTests/Fabric.Authorization.UnitTests.csproj
+++ b/Fabric.Authorization.UnitTests/Fabric.Authorization.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <DebugType>Full</DebugType>
   </PropertyGroup>
 
@@ -23,7 +23,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="1.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Moq" Version="4.7.145" />
     <PackageReference Include="Nancy.Testing" Version="2.0.0-clinteastwood" />

--- a/Fabric.Authorization.UnitTests/Fabric.Authorization.UnitTests.csproj
+++ b/Fabric.Authorization.UnitTests/Fabric.Authorization.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>    
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>Full</DebugType>
   </PropertyGroup>
 

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -6,7 +6,7 @@
     <DockerServiceUrl>http://localhost:{ServicePort}</DockerServiceUrl>
     <DockerServiceName>fabric.authorization.api</DockerServiceName>
     <DockerTargetOS>Linux</DockerTargetOS>
-    <ProjectVersion>2.0</ProjectVersion>
+    <ProjectVersion>2.2</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="docker-compose.ci.build.yml" />


### PR DESCRIPTION
Upgrading Fabric.Authorization to .net core 2.1.10.

To build and run with this version ensure you have these versions of the SDK and hosting components:
- dotnet core sdk 2.1.603: https://dotnet.microsoft.com/download/thank-you/dotnet-sdk-2.1.603-windows-x64-installer
- runtime and hosting bundle: https://dotnet.microsoft.com/download/thank-you/dotnet-runtime-2.1.10-windows-hosting-bundle-installer