### PR TITLE
Restrict to only allow JWT tokens. This fixes an error where a 500 wa…

### DIFF
--- a/Fabric.Authorization.API/Startup.cs
+++ b/Fabric.Authorization.API/Startup.cs
@@ -64,6 +64,7 @@ namespace Fabric.Authorization.API
 			        options.Authority = _idServerSettings.Authority;
 			        options.RequireHttpsMetadata = false;
 			        options.ApiName = _idServerSettings.ClientId;
+                    options.SupportedTokens = SupportedTokens.Jwt;
 				});
         }
 


### PR DESCRIPTION
…s returned for an invalid token instead of a 403.

NOTE: in the future, if we want to allow reference tokens, we will need to remove this setting, and to resolve this issue, ensure we specify the api secret during installation/configuration.

See this issue for more information: https://github.com/IdentityServer/IdentityServer4/issues/1627