### PR TITLE
Handle null when user is null during startup.

### DIFF
--- a/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
+++ b/Fabric.Authorization.Persistence.SqlServer/Stores/SqlServerGroupStore.cs
@@ -245,7 +245,10 @@ namespace Fabric.Authorization.Persistence.SqlServer.Stores
             {
                 foreach (var groupUser in groupEntity.GroupUsers)
                 {
-                    groupUser.User.UserPermissions = groupUser.User.UserPermissions.Where(up => !up.IsDeleted).ToList();
+                    if (groupUser.User?.UserPermissions != null)
+                    {
+                        groupUser.User.UserPermissions = groupUser.User.UserPermissions.Where(up => !up.IsDeleted).ToList();
+                    }
                 }
             }
 


### PR DESCRIPTION
This is a short term fix to let the app start - we have to get to the root cause of why the user object is null here. The query EF is running looks like the user object is being returned, its simply not being materialized in as an object in EF for some reason. This will unblock testing - but we need to revisit it.