### PR TITLE
Roles getting unchecked if group exists

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.spec.ts
@@ -263,6 +263,36 @@ describe('CustomGroupComponent', () => {
         + `${mockUsersResponse[0].identityProviderUserPrincipalName}`);
     });
 
+    it('dont reset the roles if group name invalid', () => {
+      // Arrange
+      component.groupNameSubject.next("test");
+      // create a few roles for component.rolesForGrainAndSecurable
+      component.rolesForGrainAndSecurable.map(r => r.selected = true)
+      component.groupNameInvalid = true;
+      component.groupNameSubject.next("test123456");
+
+      // Act
+      component.ngOnInit();
+
+      // Assert
+      expect(component.rolesForGrainAndSecurable[0].selected).toBe(true)
+  });
+
+  it('reset the roles if group name valid', () => {
+    // Arrange
+    component.groupNameSubject.next("test");
+    // create a few roles for component.rolesForGrainAndSecurable
+    component.rolesForGrainAndSecurable.map(r => r.selected = true)
+    component.groupNameInvalid = false;
+    component.groupNameSubject.next("test123456");
+
+    // Act
+    component.ngOnInit();
+
+    // Assert
+    expect(component.rolesForGrainAndSecurable[0].selected).toBe(false)
+  });
+
   });
 
   describe('save button', () => {

--- a/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
+++ b/Fabric.Authorization.AccessControl/src/app/modules/access-control/custom-group/custom-group.component.ts
@@ -145,7 +145,9 @@ export class CustomGroupComponent implements OnInit, OnDestroy {
       takeUntil(this.ngUnsubscribe),
       filter((term) => !this.editMode),
       tap((term) => {
-        this.rolesForGrainAndSecurable.map(r => r.selected = false);
+        if(!this.groupNameInvalid){
+          this.rolesForGrainAndSecurable.map(r => r.selected = false);
+        }
         this.principals.map(p => p.selected = false);
         if (term && term.length > 2) {
           this.searchingGroup = true;


### PR DESCRIPTION
If the user tries to create new custom group with a group name that already exists, the roles would get unchecked when they changed the group name.  So I added an if statement to see if the user got this error, and if so, then the roles wouldn't get unchecked.