### PR TITLE
'bandaid' for race condition

### DIFF
--- a/Fabric.Authorization.AccessControl/README.md
+++ b/Fabric.Authorization.AccessControl/README.md
@@ -4,11 +4,11 @@ An Angular 6 application for managing access to the Health Catalyst Data Operati
 # Building and running
 The Access Control UI depends on components of DOS to run properly, as a result having the latest version of DOS installed is a prerequisite to running the Access Control UI.
 
-If you would like to run the Access Control UI against a development version of Fabric.Authorization which is also in this repo you need to ensure that you have .NET Core 1.1 SDK installed. The instructions below assume that you have installed DOS and will run the Access Control UI against a version of Fabric.Authorization built from the source contained in this repo.
+If you would like to run the Access Control UI against a development version of Fabric.Authorization which is also in this repo you need to ensure that you have .NET Core 2.1 SDK installed. The instructions below assume that you have installed DOS and will run the Access Control UI against a version of Fabric.Authorization built from the source contained in this repo.
 
 - Run the `setup-dependencies.ps1` PowerShell script as administrator to ensure you have the correct versions of node, npm, angular and typescript installed.
 - In Fabric.Authorization.API/appsettings.json, update the `IdentityServerConfidentialClientSettings.Authority` setting to point at your installed version of Fabric.Identity, e.g. `https://host.domain.local/identity`
-- Launch PowerShell or gitbash as administrator and in Fabric.Authorization.AccessControl folder execute `npm install' then `npm run watch` to build the angular application and watch for changes
+- Launch PowerShell or gitbash as administrator and in Fabric.Authorization.AccessControl folder execute `npm install` then `npm run watch` to build the angular application and watch for changes
 - In VS 2017 ensure the startup project is `Fabric.Authorization.API` and the debug profile is set to `IIS`.
 - In VS 2017 begin debugging by pressing `F5`
 - In IIS, a new web application will be created `AuthorizationDev`.  You will need to change the app pool; I suggest changing it the the same one as Authorization.

--- a/Fabric.Authorization.AccessControl/src/app/services/current-user.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/current-user.service.ts
@@ -1,5 +1,5 @@
 
-import {map, tap} from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 import { Injectable } from '@angular/core';
 import { FabricAuthUserService } from './fabric-auth-user.service';
 import { Observable, of } from 'rxjs';
@@ -17,10 +17,13 @@ export class CurrentUserService {
   getPermissions(securableItem: string): Observable<string[]> {
     const currentTimeStamp = new Date().getTime();
     if (this.shouldRefreshCache(securableItem, currentTimeStamp)) {
+      return this.authUserService.getCurrentUserPermissions(securableItem).pipe(
+         tap(userPermissionResponse => {
           this.lastUpdateTimestampMap.set(securableItem, currentTimeStamp);
-          return this.authUserService.getCurrentUserPermissions(securableItem).pipe(tap(userPermissionResponse => {
-            this.permissionMap.set(securableItem, userPermissionResponse.permissions);
-      }), map(p => p.permissions));
+          this.permissionMap.set(securableItem, userPermissionResponse.permissions);
+        }),
+        map(p => p.permissions)
+      );
     }
 
     return of(this.permissionMap.get(securableItem));
@@ -33,6 +36,6 @@ export class CurrentUserService {
   private shouldRefreshCache(securableItem: string, currentTimeStamp: number): boolean {
     return !this.lastUpdateTimestampMap.has(securableItem)
         || this.lastUpdateTimestampMap.get(securableItem) === 0
-        || (Math.abs(currentTimeStamp - this.lastUpdateTimestampMap.get(securableItem)) / 60000) > 2
+        || (Math.abs(currentTimeStamp - this.lastUpdateTimestampMap.get(securableItem)) / 60000) > 2;
   }
 }


### PR DESCRIPTION
There is a race condition occurring, due to the UI tests speeding through the initial member-list page which hits the current-user service.  Then the test navigates to the member page which also hits the user service. 

Occasionally, the api call to authorization would not yet be resolved so the UI test would get back the cached permissions which were still undefined. 
