### PR TITLE
Remove EDW Admin role migration

### DIFF
--- a/Fabric.Authorization.API/appsettings.json
+++ b/Fabric.Authorization.API/appsettings.json
@@ -32,7 +32,7 @@
     },
     "DefaultPropertySettings": {
         "GroupSource": "Directory",
-        "DualStoreEDWAdminPermissions": "true",
+        "DualStoreEDWAdminPermissions": "false",
         "IdentityProvider": "Windows"
     },
     "ConnectionStrings": {

--- a/Fabric.Authorization.API/scripts/Install-Authorization.ps1
+++ b/Fabric.Authorization.API/scripts/Install-Authorization.ps1
@@ -125,6 +125,4 @@ Add-AuthorizationRegistration -clientId "fabric-access-control" -clientName "Fab
 
 Move-DosAdminRoleToDosAdminGroup -authUrl "$authorizationServiceUrl/v1" -accessToken $accessToken -connectionString $authorizationDatabase.DbConnectionString -groupName $dosAdminGroupName
 Add-AccountToDosAdminGroup -accountName $adminAccount.AdminAccountName -domain $adminAccount.UserDomain -authorizationServiceUrl "$authorizationServiceUrl/v1" -accessToken $accessToken -connString $authorizationDatabase.DbConnectionString
-Add-AccountToEDWAdmin -accountName $adminAccount.AdminAccountName -domain $adminAccount.UserDomain -connString $metadataDatabase.DbConnectionString
-Add-EdwAdminUsersToDosAdminGroup -metadataConnStr $metadataDatabase.DbConnectionString -authorizationDbConnStr $authorizationDatabase.DbConnectionString -authorizationServiceUrl $authorizationServiceUrl -accessToken $accessToken
 Invoke-MonitorShallow "$authorizationServiceUrl"


### PR DESCRIPTION
EDW Console is being retired as of DOS 19.2, so the  "EDW Admin" RoleNM from the RoleBASE table will no longer be used. This pull request is to remove the migration of this role during install and disable the dual store used by Fabric.Auth service.
- Remove calls to `Add-AccountToEDWAdmin` and `Add-EdwAdminUsersToDosAdminGroup` from install script
- Disable `DualStoreEDWAdminPermissions` in `appsettings.json`.