### PR TITLE
Remove Access Control client check for idPSS endpoint in discovery

### DIFF
--- a/Fabric.Authorization.AccessControl/src/app/services/global/services.service.spec.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/services.service.spec.ts
@@ -24,125 +24,11 @@ describe('ServicesService', () => {
     expect(service).toBeTruthy();
   }));
 
-  it('matches correct service requireAuthToken, when Idpss service out of order, and camel case',
-    inject(
-      [ServicesService], (service: ServicesService) => {
-        var strUrl = "https://testdomain.local/IdentityProviderSearchService/v1";
-        let listOfServices: IService[] = [
-          {
-            name: 'IdentityService',
-            version: 1.1,
-            url: 'https://testdomain.local/Identity',
-            requireAuthToken: false
-          },
-          {
-            name: 'IdentityProviderSearchService',
-            version: 1.2,
-            url: 'https://testdomain.local/IdentityProviderSearchService/v1',
-            requireAuthToken: true
-          },
-          {
-              name: 'AuthorizationService',
-              version: 1.3,
-              url: 'https://testdomain.local/Authorization/v1',
-              requireAuthToken: true
-          },
-          {
-              name: 'AccessControl',
-              version: 1.4,
-              url: 'https://testdomain.local/Authorization',
-              requireAuthToken: false
-          }
-      ];
-
-        service.services = listOfServices;
-        var result = service.needsAuthToken(strUrl);
-        expect(result).toBeTruthy();
-  }));
-
-  it('matches correct service requireAuthToken, when Idpss service out of order, and lower case',
-  inject(
-    [ServicesService], (service: ServicesService) => {
-      var strUrl = "https://testdomain.local/identityprovidersearchservice/v1";
-      let listOfServices: IService[] = [
-        {
-          name: 'identityservice',
-          version: 1.1,
-          url: 'https://testdomain.local/identity',
-          requireAuthToken: false
-        },
-        {
-          name: 'identityprovidersearchservice',
-          version: 1.2,
-          url: 'https://testdomain.local/identityprovidersearchservice/v1',
-          requireAuthToken: true
-        },
-        {
-            name: 'AuthorizationService',
-            version: 1.3,
-            url: 'https://testdomain.local/Authorization/v1',
-            requireAuthToken: true
-        },
-        {
-            name: 'AccessControl',
-            version: 1.4,
-            url: 'https://testdomain.local/Authorization',
-            requireAuthToken: false
-        }
-    ];
-
-      service.services = listOfServices;
-      var result = service.needsAuthToken(strUrl);
-      expect(result).toBeTruthy();
-  }));
-
-  it('matches correct service requireAuthToken, when Idpss service out of order, and mixed case',
-  inject(
-    [ServicesService], (service: ServicesService) => {
-      var strUrl = "https://testdomain.local/IdentityProviderSearchService/v1";
-      let listOfServices: IService[] = [
-        {
-          name: 'identityservice',
-          version: 1.1,
-          url: 'https://testdomain.local/identity',
-          requireAuthToken: false
-        },
-        {
-          name: 'identityprovidersearchservice',
-          version: 1.2,
-          url: 'https://testdomain.local/identityprovidersearchservice/v1',
-          requireAuthToken: true
-        },
-        {
-            name: 'AuthorizationService',
-            version: 1.3,
-            url: 'https://testdomain.local/Authorization/v1',
-            requireAuthToken: true
-        },
-        {
-            name: 'AccessControl',
-            version: 1.4,
-            url: 'https://testdomain.local/Authorization',
-            requireAuthToken: false
-        }
-    ];
-
-      service.services = listOfServices;
-      var result = service.needsAuthToken(strUrl);
-      expect(result).toBeTruthy();
-  }));
-
   it('matches correct service requireAuthToken, when identity service not listed first, and camel case',
   inject(
     [ServicesService], (service: ServicesService) => {
       var strUrl = "https://testdomain.local/Identity";
       let listOfServices: IService[] = [
-        {
-          name: 'IdentityProviderSearchService',
-          version: 1.2,
-          url: 'https://testdomain.local/IdentityProviderSearchService/v1',
-          requireAuthToken: true
-        },
         {
           name: 'IdentityService',
           version: 1.1,
@@ -174,12 +60,6 @@ describe('ServicesService', () => {
       var strUrl = "https://testdomain.local/identity";
       let listOfServices: IService[] = [
         {
-          name: 'identityprovidersearchservice',
-          version: 1.2,
-          url: 'https://testdomain.local/identityprovidersearchservice/v1',
-          requireAuthToken: true
-        },
-        {
           name: 'identityservice',
           version: 1.1,
           url: 'https://testdomain.local/identity',
@@ -210,12 +90,6 @@ describe('ServicesService', () => {
       var strUrl = "https://testdomain.local/Identity";
       let listOfServices: IService[] = [
         {
-          name: 'identityprovidersearchservice',
-          version: 1.2,
-          url: 'https://testdomain.local/identityprovidersearchservice/v1',
-          requireAuthToken: true
-        },
-        {
           name: 'identityservice',
           version: 1.1,
           url: 'https://testdomain.local/identity',
@@ -245,12 +119,6 @@ describe('ServicesService', () => {
     [ServicesService], (service: ServicesService) => {
       var strUrl = "https://testdomain.local/Identity/api/principals/search";
       let listOfServices: IService[] = [
-        {
-          name: 'identityprovidersearchservice',
-          version: 1.2,
-          url: 'https://testdomain.local/identityprovidersearchservice/v1',
-          requireAuthToken: true
-        },
         {
           name: 'identityservice',
           version: 1.1,
@@ -288,12 +156,6 @@ describe('ServicesService', () => {
             requireAuthToken: false
           },
           {
-            name: 'IdentityProviderSearchService',
-            version: 1.2,
-            url: 'https://testdomain.local/IdentityProviderSearchService/v1',
-            requireAuthToken: true
-          },
-          {
             name: 'AccessControl',
             version: 1.4,
             url: 'https://testdomain.local/Authorization',
@@ -322,12 +184,6 @@ describe('ServicesService', () => {
           version: 1.1,
           url: 'https://testdomain.local/identity',
           requireAuthToken: false
-        },
-        {
-          name: 'identityprovidersearchservice',
-          version: 1.2,
-          url: 'https://testdomain.local/identityprovidersearchservice/v1',
-          requireAuthToken: true
         },
         {
           name: 'AccessControl',
@@ -360,12 +216,6 @@ describe('ServicesService', () => {
           requireAuthToken: false
         },
         {
-          name: 'identityprovidersearchservice',
-          version: 1.2,
-          url: 'https://testdomain.local/identityprovidersearchservice/v1',
-          requireAuthToken: true
-        },
-        {
           name: 'AccessControl',
           version: 1.4,
           url: 'https://testdomain.local/authorization',
@@ -396,12 +246,6 @@ describe('ServicesService', () => {
           requireAuthToken: false
         },
         {
-          name: 'IdentityProviderSearchService',
-          version: 1.2,
-          url: 'https://testdomain.local/IdentityProviderSearchService/v1',
-          requireAuthToken: true
-        },
-        {
           name: 'AuthorizationService',
           version: 1.3,
           url: 'https://testdomain.local/Authorization/v1',
@@ -430,12 +274,6 @@ describe('ServicesService', () => {
           version: 1.1,
           url: 'https://testdomain.local/Identity',
           requireAuthToken: false
-        },
-        {
-          name: 'IdentityProviderSearchService',
-          version: 1.2,
-          url: 'https://testdomain.local/IdentityProviderSearchService/v1',
-          requireAuthToken: true
         },
         {
           name: 'AuthorizationService',

--- a/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/global/services.service.ts
@@ -35,10 +35,6 @@ export class ServicesService {
             requireAuthToken: true
         },
         {
-            name: 'IdentityProviderSearchService',
-            requireAuthToken: true
-        },
-        {
             name: 'AccessControl',
             requireAuthToken: false
         },
@@ -97,11 +93,6 @@ export class ServicesService {
 
     get authorizationServiceEndpoint(): string {
         const url = this.services.find(s => s.name === 'AuthorizationService').url;
-        return this.trimRightChar(url, '/');
-    }
-
-    get identityProviderSearchServiceEndpoint(): string {
-        const url = this.services.find(s => s.name === 'IdentityProviderSearchService').url;
         return this.trimRightChar(url, '/');
     }
 

--- a/Fabric.Authorization.AccessControl/src/app/services/interceptors/fabric-http-fake-discovery-interceptor.service.ts
+++ b/Fabric.Authorization.AccessControl/src/app/services/interceptors/fabric-http-fake-discovery-interceptor.service.ts
@@ -24,8 +24,6 @@ export class FabricHttpFakeDiscoveryInterceptorService implements HttpIntercepto
           this.responseBody = {
             "@odata.context":"http://localhost/DiscoveryService/v1/$metadata#Services(ServiceUrl,Version,ServiceName)","value":[
               {
-                "ServiceUrl":"http://localhost/IdentityProviderSearchService/v1","Version":1,"ServiceName":"IdentityProviderSearchService"
-              },{
                 "ServiceUrl":url,"Version":1,"ServiceName":"IdentityService"
               },{
                 "ServiceUrl":"http://localhost/AuthorizationDev/v1","Version":1,"ServiceName":"AuthorizationService"


### PR DESCRIPTION
Client-side initialization included discovery service call for endpoints in ServicesService.
This still included "IdentityProviderSearchService" and can throw an error if no entry exists in discovery.
IdentityProviderSearchService has been removed from the list of services to look up.

- Removed function for retrieving idPSS endpoint from ServicesService
- Removed idPSS endpoint from FabricHttpFakeDiscoveryInterceptorService used in dev environment.
- Removed idPSS-specific tests for ServicesService spec.
- Modified other ServicesService spec tests contaiing mock entries for idPSS.

196692: Unable to log into Access Control with client side error related to idPSS
https://dev.azure.com/healthcatalyst/CAP/_workitems/edit/196692